### PR TITLE
Release v1.4.0 native tree and bulk panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,21 +31,21 @@ local or be versioned and shared with the team.
 | Native VS Code experience     | Gutter decorations, CodeLens, Comments API threads, Tree View, commands, and keyboard access                 |
 | Automation and AI             | MCP tools, generated documentation, comment import, sync, and optional multi-provider AI features            |
 
-## What is new in 1.3.0
+## What is new in 1.4.0
 
-- **Re-anchor Annotation to Current Cursor** repairs an orphaned annotation,
-  including across files, while preserving its identity and discussion.
-- **Show Annotation Tracking Diagnostics** opens a local JSON report containing
-  anchor decisions, hashes, offsets, and issue codes without copying source text.
-- The annotations panel offers persisted **Comfortable** and **Compact** density
-  modes.
-- Multi-line cut/paste no longer leaves a stale original plus a duplicate at
-  the destination when the editor fragments the deletion event.
-- The Marketplace package is reduced to the runtime files actually needed by
-  the extension.
+- The native annotation tree now has open/resolved summaries, attention badges,
+  theme-aware severity icons, accessible labels, and a useful empty state.
+- Select multiple tree rows and run one native bulk action, or use each row's
+  checkbox to resolve and reopen annotations immediately.
+- The annotations panel now supports persistent multi-selection, **Select
+  visible**, and bulk Resolve, Reopen, Severity, and Delete actions.
+- Tree and panel bulk updates use one transactional command path, with native
+  VS Code Quick Picks and modal confirmation for destructive operations.
+- The 1.3 recovery tools remain available: manual re-anchoring, privacy-safe
+  tracking diagnostics, density modes, and corrected multi-line cut/paste.
 
-See the [1.3.0 release notes](./docs/CHANGELOG-1.3.0.md) or the
-[published release](https://github.com/JacquesGariepy/out-of-code-insights/releases/tag/v1.3.0).
+See the [1.4.0 release notes](./docs/CHANGELOG-1.4.0.md) or the
+[published release](https://github.com/JacquesGariepy/out-of-code-insights/releases/tag/v1.4.0).
 
 ## Start in 60 seconds
 
@@ -246,6 +246,10 @@ Attach and execute code directly from annotations:
 - **Choose panel density**:
     - Select **Comfortable** for more breathing room or **Compact** for large
       annotation sets. The choice is retained when the panel is reopened.
+- **Triage several annotations at once**:
+    - Multi-select rows in the native tree and use **Bulk Actions for Selected
+      Annotations**, or select cards in the full panel and use its bulk toolbar.
+    - Toggle a tree row's native checkbox to resolve or reopen it directly.
 
 ### Moving Annotations
 

--- a/docs/CHANGELOG-1.4.0.md
+++ b/docs/CHANGELOG-1.4.0.md
@@ -1,0 +1,31 @@
+# Out-of-Code Insights 1.4.0
+
+This release makes annotation triage faster in both the native VS Code tree and the full annotations panel.
+
+## Native annotation tree
+
+- Shows only file groups at the root; panel navigation remains in the view title toolbar.
+- Adds native TreeView badges, open/resolved summaries, attention messages and an empty-state hint.
+- Supports VS Code multi-selection and exposes a context-aware bulk-actions button.
+- Uses native checkboxes to resolve or reopen annotations directly from the tree.
+- Adds concise one-line labels, per-file state counts, theme-aware severity colors and richer tooltips.
+- Adds accessible labels for file groups and annotation rows.
+
+## Panel workflow
+
+- Adds persistent annotation selection with a visible selected-card state.
+- Adds Select visible, Resolve, Reopen, Severity, Delete and Clear selection controls.
+- Preserves selection while switching quick filters or rebuilding the panel.
+- Uses the same transactional command backend as the native tree so multi-item updates emit one store change.
+
+## Microsoft VS Code SDK integration
+
+- Uses `TreeView.badge`, `TreeView.description` and `TreeView.message` for native view status.
+- Uses `TreeItem.checkboxState` and `onDidChangeCheckboxState` for resolution state.
+- Uses `canSelectMany`, selection events and `setContext` for context-aware commands.
+- Uses `ThemeIcon`, `ThemeColor`, accessibility metadata, `QuickPick` and modal warning dialogs.
+
+## Validation
+
+- TypeScript typecheck and ESLint cover the changed extension, tree and panel sources.
+- Integration coverage verifies native tree statistics/checkbox state and multi-annotation transactional updates.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "out-of-code-insights",
-    "version": "1.3.0",
+    "version": "1.4.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "out-of-code-insights",
-            "version": "1.3.0",
+            "version": "1.4.0",
             "license": "MPL-2.0",
             "dependencies": {
                 "@anthropic-ai/claude-code": "^2.1.177",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "description": "Enhance your workflow with contextual annotations and collaborative comments stored outside the codebase, with AI integration and a dedicated chat participant.",
     "icon": "media/logo.png",
     "publisher": "jacquesgariepy",
-    "version": "1.3.0",
+    "version": "1.4.0",
     "license": "MPL-2.0",
     "author": {
         "name": "Jacques Gariépy",
@@ -93,6 +93,11 @@
                 "command": "annotations.showTrackingDiagnostics",
                 "title": "Show Annotation Tracking Diagnostics",
                 "icon": "$(pulse)"
+            },
+            {
+                "command": "annotations.bulkActions",
+                "title": "Bulk Actions for Selected Annotations",
+                "icon": "$(checklist)"
             },
             {
                 "command": "annotations.toggleDisplay",
@@ -621,6 +626,11 @@
             ],
             "view/item/context": [
                 {
+                    "command": "annotations.bulkActions",
+                    "when": "view == annotationsView && (viewItem == annotation || viewItem == annotation-linked)",
+                    "group": "navigation@0"
+                },
+                {
                     "command": "annotations.reanchorToCursor",
                     "when": "view == annotationsView && (viewItem == annotation || viewItem == annotation-linked)",
                     "group": "inline",
@@ -692,9 +702,14 @@
             ],
             "view/title": [
                 {
+                    "command": "annotations.bulkActions",
+                    "when": "view == annotationsView && outOfCodeInsights.treeSelectionCount > 0",
+                    "group": "navigation@0"
+                },
+                {
                     "command": "annotations.showTrackingDiagnostics",
                     "when": "view == annotationsView",
-                    "group": "navigation@0"
+                    "group": "navigation@1"
                 },
                 {
                     "command": "annotations.toggleDisplay",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,7 +10,11 @@ import { TextDecoder } from 'util';
 import * as vscode from 'vscode';
 import { AnnotationManager } from './managers/AnnotationManager';
 import type { Annotation } from './common/types';
-import { AnnotationsTreeDataProvider, AnnotationsDragAndDropController } from './tree/AnnotationsTree';
+import {
+    AnnotationsTreeDataProvider,
+    AnnotationsDragAndDropController,
+    AnnotationTreeItem,
+} from './tree/AnnotationsTree';
 import { NavigationStackDataProvider } from './tree/NavigationStackTree';
 import { KanbanView } from './views/KanbanView';
 import { localize } from './common/localize';
@@ -60,6 +64,7 @@ let annotationPersistence: AnnotationPersistence | undefined;
 let visibilityFilter: VisibilityFilter | undefined;
 let kanbanColumnStore: KanbanColumnStore | undefined;
 let annotationSyncService: AnnotationSyncService | undefined;
+let selectedTreeAnnotationIds: string[] = [];
 
 /** Reentrancy guard for {@link generateDocumentationNow}. */
 let docsGenerationInProgress = false;
@@ -161,12 +166,83 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         if (!annotationStore || !visibilityFilter || !annotationPersistence) {
             throw new Error('Lot 5 R2: transactional stack not bootstrapped before tree wiring');
         }
-        const treeDataProvider = new AnnotationsTreeDataProvider(annotationStore, visibilityFilter);
-        const dragAndDropController = new AnnotationsDragAndDropController(annotationStore, annotationPersistence);
+        const treeStore = annotationStore;
+        const treeDataProvider = new AnnotationsTreeDataProvider(treeStore, visibilityFilter);
+        const dragAndDropController = new AnnotationsDragAndDropController(treeStore, annotationPersistence);
         const view = vscode.window.createTreeView('annotationsView', {
             treeDataProvider,
             dragAndDropController,
+            canSelectMany: true,
         });
+        const updateTreeChrome = (): void => {
+            const stats = treeDataProvider.getStats();
+            view.badge = stats.visible
+                ? {
+                      value: stats.visible,
+                      tooltip: loc(
+                          'treeBadgeTooltip',
+                          '{0} visible annotations across {1} files',
+                          stats.visible,
+                          stats.files
+                      ),
+                  }
+                : undefined;
+            view.description = stats.visible
+                ? loc('treeViewDescription', '{0} open · {1} resolved', stats.open, stats.resolved)
+                : undefined;
+            view.message =
+                stats.total === 0
+                    ? loc('treeEmptyMessage', 'No annotations yet. Press Ctrl+Alt+A in an editor to create one.')
+                    : stats.visible === 0
+                      ? loc(
+                            'treeFilteredEmptyMessage',
+                            'Annotations exist, but the current visibility filters hide them.'
+                        )
+                      : stats.attention > 0
+                        ? loc('treeAttentionMessage', '{0} annotations need attention.', stats.attention)
+                        : undefined;
+        };
+        context.subscriptions.push(treeDataProvider.onDidChangeTreeData(updateTreeChrome));
+        context.subscriptions.push(
+            view.onDidChangeSelection((event) => {
+                selectedTreeAnnotationIds = event.selection
+                    .filter((item): item is AnnotationTreeItem => item instanceof AnnotationTreeItem)
+                    .map((item) => item.annotation.id);
+                void vscode.commands.executeCommand(
+                    'setContext',
+                    'outOfCodeInsights.treeSelectionCount',
+                    selectedTreeAnnotationIds.length
+                );
+            })
+        );
+        context.subscriptions.push(
+            view.onDidChangeCheckboxState((event) => {
+                const changes = event.items.filter(
+                    (entry): entry is [AnnotationTreeItem, vscode.TreeItemCheckboxState] =>
+                        entry[0] instanceof AnnotationTreeItem
+                );
+                if (changes.length === 0) {
+                    return;
+                }
+                treeStore.beginTransaction();
+                try {
+                    for (const [item, state] of changes) {
+                        treeStore.update(item.annotation.id, {
+                            resolved: state === vscode.TreeItemCheckboxState.Checked,
+                        });
+                    }
+                    treeStore.commit();
+                } catch (error) {
+                    treeStore.rollback();
+                    getLogger().error('Unable to update annotation resolution from TreeView checkbox', error);
+                    vscode.window.showErrorMessage(
+                        loc('treeCheckboxUpdateFailed', 'Unable to update annotation state.')
+                    );
+                }
+            })
+        );
+        updateTreeChrome();
+        void vscode.commands.executeCommand('setContext', 'outOfCodeInsights.treeSelectionCount', 0);
         // Lot 5 R2: NavigationStackTree migrated to (store, navigationStack).
         const stackDataProvider = new NavigationStackDataProvider(annotationStore, annotationManager.navigationStack);
         const stackView = vscode.window.createTreeView('stackView', { treeDataProvider: stackDataProvider });
@@ -1298,6 +1374,127 @@ function registerStoreCommands(context: vscode.ExtensionContext): void {
     );
 
     context.subscriptions.push(
+        vscode.commands.registerCommand('annotations.bulkActions', async (commandArg?: unknown) => {
+            const store = annotationStore;
+            if (!store) {
+                vscode.window.showErrorMessage(loc('storeNotReady', 'Annotation store is not ready yet.'));
+                return 0;
+            }
+
+            type BulkAction = 'resolve' | 'reopen' | 'severity' | 'delete';
+            type BulkActionArgument = { ids?: unknown; action?: unknown; severity?: unknown };
+            const argument =
+                commandArg && typeof commandArg === 'object' ? (commandArg as BulkActionArgument) : undefined;
+            let ids = Array.isArray(argument?.ids)
+                ? argument.ids.filter((id): id is string => typeof id === 'string')
+                : [];
+            if (commandArg instanceof AnnotationTreeItem) {
+                ids = selectedTreeAnnotationIds.includes(commandArg.annotation.id)
+                    ? selectedTreeAnnotationIds
+                    : [commandArg.annotation.id];
+            } else if (ids.length === 0) {
+                ids = selectedTreeAnnotationIds;
+            }
+            ids = [...new Set(ids)].filter((id) => store.get(id) !== undefined);
+            if (ids.length === 0) {
+                vscode.window.showInformationMessage(
+                    loc('bulkSelectionEmpty', 'Select one or more annotations before running a bulk action.')
+                );
+                return 0;
+            }
+
+            const suppliedAction = argument?.action;
+            let action: BulkAction | undefined =
+                suppliedAction === 'resolve' ||
+                suppliedAction === 'reopen' ||
+                suppliedAction === 'severity' ||
+                suppliedAction === 'delete'
+                    ? suppliedAction
+                    : undefined;
+            if (!action) {
+                const picked = await vscode.window.showQuickPick(
+                    [
+                        {
+                            label: '$(pass-filled) ' + loc('bulkResolve', 'Mark as resolved'),
+                            value: 'resolve' as const,
+                        },
+                        { label: '$(circle-large-outline) ' + loc('bulkReopen', 'Reopen'), value: 'reopen' as const },
+                        { label: '$(warning) ' + loc('bulkSeverity', 'Change severity'), value: 'severity' as const },
+                        { label: '$(trash) ' + loc('bulkDelete', 'Delete'), value: 'delete' as const },
+                    ],
+                    {
+                        title: loc('bulkActionTitle', 'Bulk actions'),
+                        placeHolder: loc('bulkActionPlaceholder', 'Apply an action to {0} annotations', ids.length),
+                    }
+                );
+                action = picked?.value;
+            }
+            if (!action) {
+                return 0;
+            }
+
+            let severity = typeof argument?.severity === 'string' ? argument.severity : undefined;
+            if (action === 'severity' && !severity) {
+                const picked = await vscode.window.showQuickPick(
+                    [
+                        { label: '$(info) Info', value: 'info' },
+                        { label: '$(warning) Warning', value: 'warning' },
+                        { label: '$(error) Error', value: 'error' },
+                        { label: '$(flame) Critical', value: 'critical' },
+                    ],
+                    { placeHolder: loc('bulkSeverityPlaceholder', 'Choose a severity for {0} annotations', ids.length) }
+                );
+                severity = picked?.value;
+            }
+            if (action === 'severity' && !severity) {
+                return 0;
+            }
+
+            if (action === 'delete') {
+                const deleteLabel = loc('deleteSelected', 'Delete selected');
+                const confirmation = await vscode.window.showWarningMessage(
+                    loc('confirmBulkDelete', 'Permanently delete {0} selected annotations?', ids.length),
+                    { modal: true },
+                    deleteLabel
+                );
+                if (confirmation !== deleteLabel) {
+                    return 0;
+                }
+            }
+
+            store.beginTransaction();
+            try {
+                for (const id of ids) {
+                    if (action === 'delete') {
+                        store.remove(id);
+                    } else if (action === 'resolve') {
+                        store.update(id, { resolved: true });
+                    } else if (action === 'reopen') {
+                        store.update(id, { resolved: false });
+                    } else {
+                        store.update(id, { severity });
+                    }
+                }
+                store.commit();
+            } catch (error) {
+                store.rollback();
+                getLogger().error('Bulk annotation action failed', error);
+                vscode.window.showErrorMessage(loc('bulkActionFailed', 'Unable to update the selected annotations.'));
+                return 0;
+            }
+
+            selectedTreeAnnotationIds = selectedTreeAnnotationIds.filter((id) => store.get(id) !== undefined);
+            void vscode.commands.executeCommand(
+                'setContext',
+                'outOfCodeInsights.treeSelectionCount',
+                selectedTreeAnnotationIds.length
+            );
+            vscode.window.setStatusBarMessage(loc('bulkActionComplete', 'Updated {0} annotations.', ids.length), 4000);
+            return ids.length;
+        })
+    );
+
+    context.subscriptions.push(
         vscode.commands.registerCommand('annotations.reanchorToCursor', async (commandArg?: unknown) => {
             const store = annotationStore;
             if (!store) {
@@ -1349,11 +1546,16 @@ function registerStoreCommands(context: vscode.ExtensionContext): void {
                     }))
                     .sort((left, right) => Number(right.hasIssues) - Number(left.hasIssues));
                 if (items.length === 0) {
-                    vscode.window.showInformationMessage(loc('noAnnotationsToReanchor', 'No annotations to re-anchor.'));
+                    vscode.window.showInformationMessage(
+                        loc('noAnnotationsToReanchor', 'No annotations to re-anchor.')
+                    );
                     return;
                 }
                 const picked = await vscode.window.showQuickPick(items, {
-                    placeHolder: loc('pickAnnotationToReanchor', 'Select the annotation to attach to the current cursor'),
+                    placeHolder: loc(
+                        'pickAnnotationToReanchor',
+                        'Select the annotation to attach to the current cursor'
+                    ),
                     matchOnDescription: true,
                     matchOnDetail: true,
                 });

--- a/src/managers/AnnotationManager.ts
+++ b/src/managers/AnnotationManager.ts
@@ -2265,6 +2265,12 @@ export class AnnotationManager extends EventEmitter {
                 case 'reanchor':
                     await vscode.commands.executeCommand('annotations.reanchorToCursor', message.annotationId);
                     break;
+                case 'bulkAction':
+                    await vscode.commands.executeCommand('annotations.bulkActions', {
+                        ids: message.annotationIds,
+                        action: message.action,
+                    });
+                    break;
                 case 'sort':
                     this.handleSort(message.value);
                     break;
@@ -2570,6 +2576,41 @@ export class AnnotationManager extends EventEmitter {
                 outline: 1px solid var(--vscode-focusBorder);
                 border-color: var(--vscode-focusBorder);
             }
+            .bulk-toolbar {
+                display: flex;
+                align-items: center;
+                gap: 0.55em;
+                flex-wrap: wrap;
+                padding: 0.6em 0.7em;
+                border: 1px solid var(--vscode-editorWidget-border);
+                border-radius: 8px;
+                background: var(--vscode-editor-background);
+            }
+            .bulk-toolbar.visible {
+                border-color: var(--vscode-focusBorder);
+                background: var(--vscode-list-activeSelectionBackground);
+            }
+            .bulk-count { font-weight: 700; margin-right: auto; }
+            .bulk-button {
+                border: 1px solid var(--vscode-button-border);
+                border-radius: 5px;
+                padding: 0.35em 0.65em;
+                color: var(--vscode-button-secondaryForeground);
+                background: var(--vscode-button-secondaryBackground);
+                cursor: pointer;
+            }
+            .bulk-button:hover { background: var(--vscode-button-secondaryHoverBackground); }
+            .bulk-button:disabled { opacity: 0.45; cursor: default; }
+            .bulk-button.danger { color: var(--vscode-errorForeground); }
+            .select-visible-label { display: inline-flex; align-items: center; gap: 0.4em; cursor: pointer; }
+            .annotation-select {
+                width: 1.15em;
+                height: 1.15em;
+                margin: 0 0.65em 0 0;
+                accent-color: var(--vscode-focusBorder);
+                flex: 0 0 auto;
+                cursor: pointer;
+            }
             
             .file-group {
                 margin-bottom: 2em;
@@ -2617,6 +2658,11 @@ export class AnnotationManager extends EventEmitter {
                 background-color: var(--vscode-list-hoverBackground);
                 transform: translateY(-1px);
                 box-shadow: 0 8px 24px rgba(0, 0, 0, 0.14);
+            }
+            .annotation-card.selected {
+                border-color: var(--vscode-focusBorder);
+                background: var(--vscode-list-inactiveSelectionBackground);
+                box-shadow: 0 0 0 1px var(--vscode-focusBorder);
             }
             .annotation-card:focus-visible { outline: 2px solid var(--vscode-focusBorder); outline-offset: 2px; }
             
@@ -2919,6 +2965,19 @@ export class AnnotationManager extends EventEmitter {
                     </div>
                 </div>
 
+                <div id="bulkToolbar" class="bulk-toolbar" aria-label="${loc('bulkActions', 'Bulk actions')}">
+                    <label class="select-visible-label">
+                        <input id="selectVisible" type="checkbox">
+                        ${loc('selectVisible', 'Select visible')}
+                    </label>
+                    <span id="selectedCount" class="bulk-count" role="status" aria-live="polite"></span>
+                    <button class="bulk-button" data-bulk-action="resolve" type="button">✓ ${loc('bulkResolve', 'Resolve')}</button>
+                    <button class="bulk-button" data-bulk-action="reopen" type="button">○ ${loc('bulkReopen', 'Reopen')}</button>
+                    <button class="bulk-button" data-bulk-action="severity" type="button">⚠ ${loc('bulkSeverity', 'Severity')}</button>
+                    <button class="bulk-button danger" data-bulk-action="delete" type="button">⌫ ${loc('bulkDelete', 'Delete')}</button>
+                    <button id="clearSelection" class="bulk-button" type="button">${loc('clearSelection', 'Clear selection')}</button>
+                </div>
+
                 <!-- Search results -->
                 <div id="searchResults" class="search-results-info" role="status" aria-live="polite" style="display: none;">
                 </div>
@@ -2951,11 +3010,15 @@ export class AnnotationManager extends EventEmitter {
                                  data-author="${escapeHtml(annotation.author || '')}"
                                  data-message="${escapeHtml(annotation.message.toLowerCase())}"
                                  data-action="navigate"
-                                 role="button"
+                                 role="group"
                                  tabindex="0"
                                  aria-label="${escapeHtml(`${annotation.file}, ${loc('line', 'Line')} ${annotation.line + 1}: ${annotation.message}`)}">
 
                                 <div class="annotation-header">
+                                    <input class="annotation-select"
+                                           type="checkbox"
+                                           data-select-annotation="${escapeHtml(annotation.id)}"
+                                           aria-label="${escapeHtml(loc('selectAnnotation', 'Select annotation: {0}', annotation.message))}">
                                     <span class="annotation-author">${escapeHtml(annotation.author || loc('anonymous', 'Anonymous'))}${annotation.pinned ? ' \u{1F4CC}' : ''}</span>
                                     <span class="severity-icon">${this.getSeverityIcon(annotation.severity || 'info')}</span>
                                     <span class="badge">${annotation.thread ? annotation.thread.length : 0} ${loc('comments', 'Comments')}</span>
@@ -3044,6 +3107,68 @@ export class AnnotationManager extends EventEmitter {
             const filterSelect = document.getElementById('filterOptions');
             const quickFilterButtons = Array.from(document.querySelectorAll('[data-quick-filter]'));
             const densityButtons = Array.from(document.querySelectorAll('[data-density]'));
+            const bulkToolbar = document.getElementById('bulkToolbar');
+            const selectedCount = document.getElementById('selectedCount');
+            const selectVisible = document.getElementById('selectVisible');
+            const clearSelection = document.getElementById('clearSelection');
+            const selectionInputs = Array.from(document.querySelectorAll('[data-select-annotation]'));
+            const selectedIds = new Set(Array.isArray(state.selectedAnnotationIds) ? state.selectedAnnotationIds : []);
+
+            function updateSelectionControls() {
+                const cards = Array.from(document.querySelectorAll('.annotation-card'));
+                const presentIds = new Set(cards.map((card) => card.dataset.annotationId));
+                Array.from(selectedIds).forEach((id) => {
+                    if (!presentIds.has(id)) selectedIds.delete(id);
+                });
+                cards.forEach((card) => card.classList.toggle('selected', selectedIds.has(card.dataset.annotationId)));
+                selectionInputs.forEach((input) => {
+                    input.checked = selectedIds.has(input.dataset.selectAnnotation);
+                });
+                const visibleCards = cards.filter((card) => !card.hidden);
+                const visibleSelected = visibleCards.filter((card) => selectedIds.has(card.dataset.annotationId)).length;
+                if (selectVisible) {
+                    selectVisible.checked = visibleCards.length > 0 && visibleSelected === visibleCards.length;
+                    selectVisible.indeterminate = visibleSelected > 0 && visibleSelected < visibleCards.length;
+                }
+                if (selectedCount) {
+                    selectedCount.textContent = selectedIds.size + ' ${loc('selectedAnnotations', 'selected')}';
+                }
+                bulkToolbar?.classList.toggle('visible', selectedIds.size > 0);
+                document.querySelectorAll('[data-bulk-action], #clearSelection').forEach((button) => {
+                    button.disabled = selectedIds.size === 0;
+                });
+                state.selectedAnnotationIds = Array.from(selectedIds);
+                vscode.setState(state);
+            }
+
+            selectionInputs.forEach((input) => {
+                input.addEventListener('click', (event) => event.stopPropagation());
+                input.addEventListener('change', () => {
+                    if (input.checked) selectedIds.add(input.dataset.selectAnnotation);
+                    else selectedIds.delete(input.dataset.selectAnnotation);
+                    updateSelectionControls();
+                });
+            });
+            selectVisible?.addEventListener('change', () => {
+                document.querySelectorAll('.annotation-card:not([hidden])').forEach((card) => {
+                    if (selectVisible.checked) selectedIds.add(card.dataset.annotationId);
+                    else selectedIds.delete(card.dataset.annotationId);
+                });
+                updateSelectionControls();
+            });
+            clearSelection?.addEventListener('click', () => {
+                selectedIds.clear();
+                updateSelectionControls();
+            });
+            document.querySelectorAll('[data-bulk-action]').forEach((button) => {
+                button.addEventListener('click', () => {
+                    vscode.postMessage({
+                        command: 'bulkAction',
+                        action: button.dataset.bulkAction,
+                        annotationIds: Array.from(selectedIds),
+                    });
+                });
+            });
 
             // Restore state
             if (sortSelect) sortSelect.value = state.sortOption || 'line_asc';
@@ -3093,6 +3218,7 @@ export class AnnotationManager extends EventEmitter {
                 });
                 state.quickFilter = value;
                 vscode.setState(state);
+                updateSelectionControls();
                 clearHighlights();
                 hideSearchResults();
             }
@@ -3327,6 +3453,9 @@ export class AnnotationManager extends EventEmitter {
             applyQuickFilter(state.quickFilter || 'all');
 
             document.addEventListener('keydown', (event) => {
+                if (event.target.closest?.('button, input, select, textarea, [contenteditable="true"]')) {
+                    return;
+                }
                 const card = event.target.closest?.('.annotation-card');
                 if (card && (event.key === 'Enter' || event.key === ' ')) {
                     event.preventDefault();
@@ -3350,6 +3479,9 @@ export class AnnotationManager extends EventEmitter {
 
             // Event delegation replaces all inline onclick/onblur handlers.
             document.addEventListener('click', function(e) {
+                if (e.target.closest('[data-select-annotation], [data-bulk-action], #clearSelection, #selectVisible')) {
+                    return;
+                }
                 const btn = e.target.closest('[data-action]');
                 if (!btn) { return; }
                 const action = btn.dataset.action;

--- a/src/test/suite/lot12-reanchor-diagnostics.integration.test.ts
+++ b/src/test/suite/lot12-reanchor-diagnostics.integration.test.ts
@@ -121,4 +121,34 @@ suite('Lot 12 — manual re-anchor and local diagnostics commands', () => {
         assert.ok(Array.isArray(report.annotations));
         assert.strictEqual(document.getText().includes('a very long annotated source line'), false);
     });
+
+    test('bulk command updates multiple annotations in one native command path', async function () {
+        this.timeout(20_000);
+        const uri = await fixture('lot12-bulk-actions.ts', 'first\nsecond\nthird\n');
+        const document = await vscode.workspace.openTextDocument(uri);
+        await vscode.window.showTextDocument(document);
+        await vscode.commands.executeCommand('annotations.add', { line: 0, message: 'lot12 bulk first' });
+        await vscode.commands.executeCommand('annotations.add', { line: 1, message: 'lot12 bulk second' });
+        const first = await waitForAnnotation((candidate) => candidate.message === 'lot12 bulk first');
+        const second = await waitForAnnotation((candidate) => candidate.message === 'lot12 bulk second');
+        createdIds.push(first.id, second.id);
+
+        const commands = await vscode.commands.getCommands(true);
+        assert.ok(commands.includes('annotations.bulkActions'));
+        const updated = await vscode.commands.executeCommand<number>('annotations.bulkActions', {
+            ids: [first.id, second.id],
+            action: 'resolve',
+        });
+        assert.strictEqual(updated, 2);
+        await waitForAnnotation((candidate) => candidate.id === first.id && candidate.resolved === true);
+        await waitForAnnotation((candidate) => candidate.id === second.id && candidate.resolved === true);
+
+        await vscode.commands.executeCommand('annotations.bulkActions', {
+            ids: [first.id, second.id],
+            action: 'severity',
+            severity: 'critical',
+        });
+        await waitForAnnotation((candidate) => candidate.id === first.id && candidate.severity === 'critical');
+        await waitForAnnotation((candidate) => candidate.id === second.id && candidate.severity === 'critical');
+    });
 });

--- a/src/test/suite/lot5-display.integration.test.ts
+++ b/src/test/suite/lot5-display.integration.test.ts
@@ -124,8 +124,7 @@ suite('Lot 5 R2 worktree A — AnnotationsTreeDataProvider', () => {
         subscriptions.push(provider);
 
         const roots = await provider.getChildren();
-        // First root is the "Show Annotations Panel" command item; second is the file group.
-        assert.ok(roots.length >= 2, 'expected at least one file group + the navigate item');
+        assert.strictEqual(roots.length, 1, 'the native tree root should contain file groups only');
         const fileItem = roots.find((r) => r instanceof FileTreeItem) as FileTreeItem;
         assert.ok(fileItem, 'expected a FileTreeItem');
         assert.strictEqual(fileItem.entries.length, 3);
@@ -136,6 +135,27 @@ suite('Lot 5 R2 worktree A — AnnotationsTreeDataProvider', () => {
             ids,
             [a1.id, a2.id, a3.id],
             'children must be sorted by startOffset, not insertion order'
+        );
+
+        store.update(a1.id, { resolved: true });
+        store.update(a2.id, { severity: 'warning' });
+        const stats = provider.getStats();
+        assert.deepStrictEqual(stats, {
+            total: 3,
+            visible: 3,
+            open: 2,
+            resolved: 1,
+            attention: 1,
+            files: 1,
+        });
+
+        const refreshedRoots = await provider.getChildren();
+        const refreshedFile = refreshedRoots[0] as FileTreeItem;
+        const refreshedChildren = (await provider.getChildren(refreshedFile)) as AnnotationTreeItem[];
+        assert.strictEqual(
+            refreshedChildren.find((item) => item.annotation.id === a1.id)?.checkboxState,
+            vscode.TreeItemCheckboxState.Checked,
+            'resolved state should be exposed through the native TreeView checkbox'
         );
     });
 

--- a/src/tree/AnnotationsTree.ts
+++ b/src/tree/AnnotationsTree.ts
@@ -57,6 +57,21 @@ export class AnnotationsTreeDataProvider implements vscode.TreeDataProvider<vsco
         return element;
     }
 
+    getStats(): AnnotationTreeStats {
+        const all = this.store.list();
+        const visible = all.filter((annotation) => this.visibilityFilter.isVisible(annotation));
+        return {
+            total: all.length,
+            visible: visible.length,
+            open: visible.filter((annotation) => !annotation.resolved).length,
+            resolved: visible.filter((annotation) => annotation.resolved).length,
+            attention: visible.filter((annotation) =>
+                ['warning', 'error', 'critical'].includes(annotation.severity ?? 'info')
+            ).length,
+            files: new Set(visible.map((annotation) => annotation.file)).size,
+        };
+    }
+
     async getChildren(element?: vscode.TreeItem): Promise<vscode.TreeItem[]> {
         await this.store.waitUntilInitialized();
 
@@ -84,18 +99,8 @@ export class AnnotationsTreeDataProvider implements vscode.TreeDataProvider<vsco
         }
 
         if (!element) {
-            const navigateToPanelItem = new vscode.TreeItem(
-                localize('openPanel', 'Show Annotations Panel'),
-                vscode.TreeItemCollapsibleState.None
-            );
-            navigateToPanelItem.command = {
-                command: 'annotations.show',
-                title: localize('openPanel', 'Show Annotations Panel'),
-            };
-            navigateToPanelItem.iconPath = new vscode.ThemeIcon('notebook-render-output');
-
             const groupedEntries = Array.from(grouped.entries()).map(([file, arr]) => new FileTreeItem(file, arr));
-            return [navigateToPanelItem, ...groupedEntries];
+            return groupedEntries.sort((left, right) => left.file.localeCompare(right.file));
         }
         if (element instanceof FileTreeItem) {
             return element.entries.map((e) => new AnnotationTreeItem(e.annotation, e.line, resolved));
@@ -104,16 +109,43 @@ export class AnnotationsTreeDataProvider implements vscode.TreeDataProvider<vsco
     }
 }
 
+export interface AnnotationTreeStats {
+    total: number;
+    visible: number;
+    open: number;
+    resolved: number;
+    attention: number;
+    files: number;
+}
+
 export class FileTreeItem extends vscode.TreeItem {
     constructor(
         public readonly file: string,
         public readonly entries: ResolvedAnnotation[]
     ) {
         super(file, vscode.TreeItemCollapsibleState.Expanded);
-        this.tooltip = loc('fileTooltip', `{0} ({1} annotations)`, file, entries.length);
-        this.description = loc('annotationCount', `{0} annotations`, entries.length);
+        const resolved = entries.filter(({ annotation }) => annotation.resolved).length;
+        const attention = entries.filter(({ annotation }) =>
+            ['warning', 'error', 'critical'].includes(annotation.severity ?? 'info')
+        ).length;
+        const open = entries.length - resolved;
+        this.tooltip = new vscode.MarkdownString(
+            loc(
+                'fileTreeTooltip',
+                `**{0}**\n\n{1} open · {2} resolved · {3} need attention`,
+                file,
+                open,
+                resolved,
+                attention
+            )
+        );
+        this.description = loc('fileTreeDescription', `{0} open · {1} resolved`, open, resolved);
         this.iconPath = new vscode.ThemeIcon('file-code');
         this.contextValue = 'file';
+        this.accessibilityInformation = {
+            label: loc('fileTreeAccessibility', '{0}, {1} annotations, {2} open', file, entries.length, open),
+            role: 'treeitem',
+        };
     }
 }
 
@@ -123,7 +155,12 @@ export class AnnotationTreeItem extends vscode.TreeItem {
         public readonly resolvedLine: number | null,
         siblings: readonly ResolvedAnnotation[] = []
     ) {
-        super(annotation.message, vscode.TreeItemCollapsibleState.None);
+        const firstLine = annotation.message
+            .split(/\r?\n/)
+            .map((line) => line.trim())
+            .find(Boolean);
+        const summary = firstLine && firstLine.length > 96 ? `${firstLine.slice(0, 93)}…` : firstLine || annotation.id;
+        super(summary, vscode.TreeItemCollapsibleState.None);
 
         const date = new Date(annotation.timestamp);
         const formattedDate = date.toLocaleDateString(undefined, {
@@ -154,19 +191,18 @@ export class AnnotationTreeItem extends vscode.TreeItem {
         }
 
         const hasLinks = hasOutgoingLinks || hasIncomingLinks;
-        const linkIndicator = hasLinks ? '🔗 ' : '';
 
         const lineLabel = resolvedLine === null ? '?' : String(resolvedLine + 1);
+        const stateLabel = annotation.resolved ? loc('resolved', 'resolved') : loc('open', 'open');
+        const replyCount = annotation.thread?.length ?? 0;
 
         this.description = loc(
-            'annotationDescription',
-            `{0}Line {1} • {2} • {3} • {4} {5}`,
-            linkIndicator,
+            'annotationTreeDescription',
+            `L{0} · {1} · {2}{3}`,
             lineLabel,
-            annotation.author || loc('anonymous', 'Anonymous'),
             annotation.severity || 'info',
-            formattedDate,
-            formattedTime
+            stateLabel,
+            replyCount > 0 ? loc('treeReplySuffix', ' · {0} replies', replyCount) : ''
         );
 
         let tooltipContent =
@@ -229,9 +265,32 @@ export class AnnotationTreeItem extends vscode.TreeItem {
                 break;
         }
 
-        this.iconPath = new vscode.ThemeIcon(iconName);
+        const iconColor = annotation.resolved
+            ? new vscode.ThemeColor('testing.iconPassed')
+            : annotation.severity === 'error' || annotation.severity === 'critical'
+              ? new vscode.ThemeColor('problemsErrorIcon.foreground')
+              : annotation.severity === 'warning'
+                ? new vscode.ThemeColor('problemsWarningIcon.foreground')
+                : annotation.pinned
+                  ? new vscode.ThemeColor('charts.yellow')
+                  : undefined;
+        this.iconPath = new vscode.ThemeIcon(iconName, iconColor);
+        this.checkboxState = annotation.resolved
+            ? vscode.TreeItemCheckboxState.Checked
+            : vscode.TreeItemCheckboxState.Unchecked;
         this.contextValue = hasLinks ? 'annotation-linked' : 'annotation';
         this.resourceUri = vscode.Uri.parse(`annotation:${annotation.id}`);
+        this.accessibilityInformation = {
+            label: loc(
+                'annotationTreeAccessibility',
+                '{0}, line {1}, severity {2}, {3}',
+                summary,
+                lineLabel,
+                annotation.severity || 'info',
+                stateLabel
+            ),
+            role: 'treeitem',
+        };
         this.command = {
             command: 'annotations.navigate',
             title: loc('navigateToAnnotation', 'Navigate to Annotation'),

--- a/tasks.jsonp
+++ b/tasks.jsonp
@@ -1,7 +1,7 @@
 globalThis.OOCI_TASKS = {
   "schemaVersion": 1,
   "project": "Out-of-Code Insights augmented platform",
-  "updatedAt": "2026-07-12T18:15:09-04:00",
+  "updatedAt": "2026-07-12T18:34:00-04:00",
   "statuses": ["todo", "in_progress", "blocked", "done", "accepted", "investigate"],
   "tasks": [
     {"id":"TRACK-001","area":"tracking","title":"Recognize paste over a selected range","status":"done"},
@@ -23,6 +23,9 @@ globalThis.OOCI_TASKS = {
     {"id":"UI-EXT-005","area":"vscode-ui","title":"Add keyboard navigation, ARIA, visible focus and reduced motion","status":"done"},
     {"id":"UI-EXT-006","area":"vscode-ui","title":"Add drag affordances and editor drag feedback","status":"done"},
     {"id":"UI-EXT-007","area":"vscode-ui","title":"Replace full HTML reloads with incremental state messages","status":"todo"},
+    {"id":"UI-EXT-008","area":"vscode-ui","title":"Upgrade TreeView hierarchy, summaries, theme icons, accessibility and resolved-state checkboxes","status":"done"},
+    {"id":"UI-EXT-009","area":"vscode-ui","title":"Add persisted multi-selection and transactional bulk actions to the annotations panel","status":"done"},
+    {"id":"SDK-VSCODE-001","area":"microsoft-sdk","title":"Use TreeView badges, messages, multi-selection, checkbox events, context keys, ThemeColor and native QuickPick workflows","status":"done"},
     {"id":"DESKTOP-001","area":"tauri","title":"Align desktop envelope and migrations 1:1 with extension","status":"in_progress"},
     {"id":"DESKTOP-002","area":"tauri","title":"Add direct drag-and-drop re-anchoring from table to code preview","status":"done"},
     {"id":"DESKTOP-003","area":"tauri","title":"Add bulk select/resolve/reopen/severity/delete workflows","status":"done"},
@@ -39,10 +42,13 @@ globalThis.OOCI_TASKS = {
     {"id":"QA-003","area":"quality","title":"Run full VS Code Electron integration suite (407 passing, 6 pending)","status":"done"},
     {"id":"QA-004","area":"quality","title":"Build/test Tauri frontend, 20 React tests and Rust backend","status":"done"},
     {"id":"QA-005","area":"quality","title":"Visual QA: desktop/narrow/high-contrast/reduced-motion","status":"blocked","blocker":"In-app browser runtime did not start; retry after environment recovery."},
+    {"id":"QA-006","area":"quality","title":"Validate v1.4.0 native TreeView and panel bulk workflows","status":"done"},
     {"id":"DOC-001","area":"documentation","title":"Modernize README positioning, onboarding, 1.3 recovery workflows, commands and troubleshooting","status":"done"},
+    {"id":"DOC-002","area":"documentation","title":"Document v1.4.0 native tree, panel selection and Microsoft SDK workflows","status":"done"},
     {"id":"REL-001","area":"release","title":"Publish extension v1.2.1 to GitHub, VS Code Marketplace and Open VSX","status":"done"},
     {"id":"REL-002","area":"release","title":"Publish desktop v0.1.1 with NSIS and MSI installers","status":"done"},
-    {"id":"REL-003","area":"release","title":"Publish extension v1.3.0 recovery, diagnostics and density release","status":"done"}
+    {"id":"REL-003","area":"release","title":"Publish extension v1.3.0 recovery, diagnostics and density release","status":"done"},
+    {"id":"REL-004","area":"release","title":"Publish extension v1.4.0 native tree and bulk panel release","status":"in_progress"}
   ],
   "productThoughts": [
     {"id":"THOUGHT-001","status":"accepted","text":"Identity must follow semantic code movement; line numbers and hashes alone are insufficient."},
@@ -53,6 +59,7 @@ globalThis.OOCI_TASKS = {
     {"id":"THOUGHT-006","status":"investigate","text":"AST symbol identity plus block fingerprint and Git diff mapping may outperform line-context anchors."},
     {"id":"THOUGHT-007","status":"investigate","text":"A shared local operation ledger could reconcile concurrent extension/desktop writes without a server."},
     {"id":"THOUGHT-008","status":"investigate","text":"Retire the legacy manager after porting its clipboard heuristics; two lifecycle engines are a regression risk."},
-    {"id":"THOUGHT-009","status":"accepted","text":"Tracking diagnostics must expose hashes and decisions without copying proprietary source text into reports."}
+    {"id":"THOUGHT-009","status":"accepted","text":"Tracking diagnostics must expose hashes and decisions without copying proprietary source text into reports."},
+    {"id":"THOUGHT-010","status":"accepted","text":"Use Microsoft VS Code native surfaces for selection, confirmation, theme, accessibility and commands; keep the webview focused on dense cross-file workflows."}
   ]
 };


### PR DESCRIPTION
## What changed

- modernizes the native annotation TreeView with badges, summaries, themed icons, accessibility, multi-selection and resolved-state checkboxes
- adds persistent multi-selection and transactional bulk actions to the annotations panel
- centralizes tree and panel bulk workflows in one VS Code command using native QuickPick and modal confirmation
- bumps the extension to 1.4.0 and documents the release and tracked task status

## Why

Large annotation sets required repetitive one-item actions, while the TreeView exposed little workspace state and duplicated panel navigation as a fake row. This release uses Microsoft VS Code SDK surfaces directly and keeps the panel focused on dense cross-file triage.

## Validation

- TypeScript typecheck
- ESLint on changed sources
- 492 Node tests passing
- 407 VS Code Electron tests passing, 6 pending; one unrelated clipboard timing scenario failed once and passed on targeted rerun
- targeted native tree and bulk command Electron tests passing
- production webpack build
- VSIX 1.4.0 packaged successfully
