### PR TITLE
Release v1.4.1 drag-and-drop moves

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,7 @@ test-fixtures/lot10-*.md
 test-fixtures/docs/
 
 test-fixtures/lot10-*.ts
+test-fixtures/lot5-drag-*
 
 # Agent worktrees
 .claude/worktrees/

--- a/README.md
+++ b/README.md
@@ -31,21 +31,21 @@ local or be versioned and shared with the team.
 | Native VS Code experience     | Gutter decorations, CodeLens, Comments API threads, Tree View, commands, and keyboard access                 |
 | Automation and AI             | MCP tools, generated documentation, comment import, sync, and optional multi-provider AI features            |
 
-## What is new in 1.4.0
+## What is new in 1.4.1
 
-- The native annotation tree now has open/resolved summaries, attention badges,
-  theme-aware severity icons, accessible labels, and a useful empty state.
-- Select multiple tree rows and run one native bulk action, or use each row's
-  checkbox to resolve and reopen annotations immediately.
-- The annotations panel now supports persistent multi-selection, **Select
-  visible**, and bulk Resolve, Reopen, Severity, and Delete actions.
-- Tree and panel bulk updates use one transactional command path, with native
-  VS Code Quick Picks and modal confirmation for destructive operations.
-- The 1.3 recovery tools remain available: manual re-anchoring, privacy-safe
-  tracking diagnostics, density modes, and corrected multi-line cut/paste.
+- Drag annotations onto another annotation in the native tree or the full panel
+  to re-anchor them at the destination, including across files.
+- Multi-selected annotations move together while preserving their identity,
+  discussions, metadata, and relative line spacing.
+- Panel cards now provide dedicated drag handles and visible card/file drop
+  targets.
+- **Move Selected Annotations…** provides the same workflow through native VS
+  Code pickers for keyboard and assistive-technology users.
+- Tree drops no longer rewrite every annotation line according to its list
+  position; only the explicitly dragged annotations move.
 
-See the [1.4.0 release notes](./docs/CHANGELOG-1.4.0.md) or the
-[published release](https://github.com/JacquesGariepy/out-of-code-insights/releases/tag/v1.4.0).
+See the [1.4.1 release notes](./docs/CHANGELOG-1.4.1.md) or the
+[published release](https://github.com/JacquesGariepy/out-of-code-insights/releases/tag/v1.4.1).
 
 ## Start in 60 seconds
 
@@ -255,6 +255,11 @@ Attach and execute code directly from annotations:
 
 - Drag or move code normally in the editor; attached annotations follow the
   affected lines and blocks.
+- Drag an annotation row onto another row in the native tree, or use the drag
+  handle on a panel card, to move the annotation to that code location.
+- Multi-select annotations before dragging to move the set together. Drop on a
+  file group to choose an exact line with the native destination picker.
+- Run **Move Selected Annotations…** for the keyboard-accessible equivalent.
 - Use **Move Annotation Up** or **Move Annotation Down** for a deliberate
   one-line adjustment.
 - To recover an orphan or deliberately move it elsewhere, place the cursor on

--- a/docs/CHANGELOG-1.4.1.md
+++ b/docs/CHANGELOG-1.4.1.md
@@ -1,0 +1,26 @@
+# Out-of-Code Insights 1.4.1
+
+This focused release makes annotation drag-and-drop a real movement workflow instead of a visual reorder.
+
+## Drag-and-drop movement
+
+- Drag one annotation onto another annotation in the native TreeView to re-anchor it at the destination.
+- Move annotations across files without changing their ids, threads, tags, severity or resolution state.
+- Drag a multi-selection together while preserving its relative line spacing.
+- Drop onto a file group to choose the exact destination line with a native VS Code picker.
+- Use **Move Selected Annotations…** from the Command Palette or tree context menu as an accessible alternative.
+
+## Panel UI
+
+- Every annotation card now has a dedicated drag handle.
+- Selected cards move together when one selected handle is dragged.
+- Cards and file groups show clear drop-target feedback.
+- Dragging state follows VS Code theme colors and reduced-motion preferences.
+
+## Important fix
+
+The previous tree implementation treated a drop as list reordering and re-anchored every annotation in the file to its list index. A drop now updates only the annotations being moved and recaptures their anchors against the actual destination document.
+
+## Release cadence
+
+This is intentionally a focused patch release. The deeper panel hierarchy and incremental-rendering work is tracked for 1.4.2, while advanced editor-drop and workspace workflows are tracked separately for 1.5.0.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "out-of-code-insights",
-    "version": "1.4.0",
+    "version": "1.4.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "out-of-code-insights",
-            "version": "1.4.0",
+            "version": "1.4.1",
             "license": "MPL-2.0",
             "dependencies": {
                 "@anthropic-ai/claude-code": "^2.1.177",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "description": "Enhance your workflow with contextual annotations and collaborative comments stored outside the codebase, with AI integration and a dedicated chat participant.",
     "icon": "media/logo.png",
     "publisher": "jacquesgariepy",
-    "version": "1.4.0",
+    "version": "1.4.1",
     "license": "MPL-2.0",
     "author": {
         "name": "Jacques Gariépy",
@@ -98,6 +98,11 @@
                 "command": "annotations.bulkActions",
                 "title": "Bulk Actions for Selected Annotations",
                 "icon": "$(checklist)"
+            },
+            {
+                "command": "annotations.moveByDragAndDrop",
+                "title": "Move Selected Annotations…",
+                "icon": "$(move)"
             },
             {
                 "command": "annotations.toggleDisplay",
@@ -629,6 +634,11 @@
                     "command": "annotations.bulkActions",
                     "when": "view == annotationsView && (viewItem == annotation || viewItem == annotation-linked)",
                     "group": "navigation@0"
+                },
+                {
+                    "command": "annotations.moveByDragAndDrop",
+                    "when": "view == annotationsView && (viewItem == annotation || viewItem == annotation-linked)",
+                    "group": "navigation@1"
                 },
                 {
                     "command": "annotations.reanchorToCursor",

--- a/src/commands/AnnotationMoveService.ts
+++ b/src/commands/AnnotationMoveService.ts
@@ -1,0 +1,186 @@
+// SPDX-License-Identifier: MPL-2.0
+import * as vscode from 'vscode';
+import { loc } from '../managers/LocalizationManager';
+import type { AnnotationPersistence } from '../transactional/AnnotationPersistence';
+import type { AnnotationStore } from '../transactional/AnnotationStore';
+import type { AnnotationV2 } from '../transactional/types';
+
+export const ANNOTATION_DRAG_MIME = 'application/vnd.code.tree.annotation';
+
+export interface MoveAnnotationsRequest {
+    ids: readonly string[];
+    targetAnnotationId?: string;
+    targetFile?: string;
+    targetLine?: number;
+}
+
+export interface MoveAnnotationsResult {
+    movedIds: string[];
+    file: string;
+    firstLine: number;
+}
+
+/**
+ * Shared move engine used by native TreeView drops, the panel webview and the
+ * keyboard-accessible command. A move preserves annotation ids and discussion
+ * metadata while recapturing the anchor against the destination document.
+ */
+export class AnnotationMoveService {
+    constructor(
+        private readonly store: AnnotationStore,
+        private readonly persistence: AnnotationPersistence
+    ) {}
+
+    async move(request: MoveAnnotationsRequest): Promise<MoveAnnotationsResult | undefined> {
+        const ids = [...new Set(request.ids)].filter((id) => this.store.get(id) !== undefined);
+        const movableIds = request.targetAnnotationId ? ids.filter((id) => id !== request.targetAnnotationId) : ids;
+        if (movableIds.length === 0) {
+            return undefined;
+        }
+
+        const target = await this.resolveTarget(request, new Set(movableIds));
+        if (!target) {
+            return undefined;
+        }
+
+        const sourceLocations = await this.resolveSourceLocations(movableIds);
+        const sameSourceFile = sourceLocations.every(
+            (entry) => entry.annotation.fileUri === sourceLocations[0]?.annotation.fileUri
+        );
+        const baseSourceLine = sameSourceFile ? Math.min(...sourceLocations.map((entry) => entry.line)) : 0;
+        sourceLocations.sort((left, right) => {
+            const fileOrder = left.annotation.file.localeCompare(right.annotation.file);
+            return fileOrder || left.line - right.line || left.annotation.startOffset - right.annotation.startOffset;
+        });
+
+        this.store.beginTransaction();
+        try {
+            sourceLocations.forEach((entry, index) => {
+                const relativeLine = sameSourceFile ? entry.line - baseSourceLine : index;
+                const destinationLine = Math.max(
+                    0,
+                    Math.min(target.document.lineCount - 1, target.line + relativeLine)
+                );
+                this.store.reanchor(
+                    entry.annotation.id,
+                    destinationLine,
+                    target.document,
+                    vscode.workspace.asRelativePath(target.document.uri)
+                );
+            });
+            this.store.commit();
+        } catch (error) {
+            this.store.rollback();
+            throw error;
+        }
+
+        await this.persistence.save(this.store.serialize());
+        return {
+            movedIds: sourceLocations.map((entry) => entry.annotation.id),
+            file: vscode.workspace.asRelativePath(target.document.uri),
+            firstLine: target.line,
+        };
+    }
+
+    private async resolveTarget(
+        request: MoveAnnotationsRequest,
+        movingIds: ReadonlySet<string>
+    ): Promise<{ document: vscode.TextDocument; line: number } | undefined> {
+        let targetAnnotation: Readonly<AnnotationV2> | undefined;
+        if (request.targetAnnotationId) {
+            targetAnnotation = this.store.get(request.targetAnnotationId);
+        } else if (!request.targetFile && request.targetLine === undefined) {
+            const picked = await vscode.window.showQuickPick(
+                this.store
+                    .list()
+                    .filter((annotation) => !movingIds.has(annotation.id))
+                    .map((annotation) => ({
+                        label: annotation.message.split(/\r?\n/, 1)[0] || annotation.id,
+                        description: annotation.file,
+                        detail: loc('dropTargetDetail', 'Drop beside this annotation'),
+                        annotation,
+                    })),
+                {
+                    title: loc('moveAnnotationsTitle', 'Move annotations'),
+                    placeHolder: loc('pickDropTarget', 'Choose the destination annotation'),
+                    matchOnDescription: true,
+                    matchOnDetail: true,
+                }
+            );
+            targetAnnotation = picked?.annotation;
+            if (!targetAnnotation) {
+                return undefined;
+            }
+        }
+
+        const fileCandidate = targetAnnotation
+            ? targetAnnotation
+            : this.store.list().find((annotation) => annotation.file === request.targetFile);
+        if (!fileCandidate) {
+            throw new Error(loc('dropTargetFileMissing', 'The destination file is no longer available.'));
+        }
+
+        const document = await vscode.workspace.openTextDocument(vscode.Uri.parse(fileCandidate.fileUri));
+        let line = request.targetLine;
+        if (line === undefined && targetAnnotation) {
+            line = document.positionAt(targetAnnotation.startOffset).line;
+        }
+        if (line === undefined) {
+            const activeEditor = vscode.window.activeTextEditor;
+            const suggestedLine =
+                activeEditor?.document.uri.toString() === document.uri.toString()
+                    ? activeEditor.selection.active.line
+                    : document.positionAt(fileCandidate.startOffset).line;
+            line = await this.pickDestinationLine(document, suggestedLine);
+        }
+        if (line === undefined) {
+            return undefined;
+        }
+        return { document, line: Math.max(0, Math.min(document.lineCount - 1, line)) };
+    }
+
+    private async pickDestinationLine(
+        document: vscode.TextDocument,
+        suggestedLine: number
+    ): Promise<number | undefined> {
+        const candidates = Array.from({ length: Math.min(document.lineCount, 2000) }, (_, line) => ({
+            label: loc('lineNumberLabel', 'Line {0}', line + 1),
+            description: document.lineAt(line).text.trim().slice(0, 120),
+            line,
+        }));
+        const suggested = candidates[Math.max(0, Math.min(candidates.length - 1, suggestedLine))];
+        const orderedCandidates = suggested
+            ? [suggested, ...candidates.filter((candidate) => candidate.line !== suggested.line)]
+            : candidates;
+        const picked = await vscode.window.showQuickPick(orderedCandidates, {
+            title: loc('moveAnnotationsTitle', 'Move annotations'),
+            placeHolder: loc(
+                'pickDestinationLine',
+                'Choose a destination line in {0}',
+                vscode.workspace.asRelativePath(document.uri)
+            ),
+            matchOnDescription: true,
+        });
+        return picked?.line;
+    }
+
+    private async resolveSourceLocations(
+        ids: readonly string[]
+    ): Promise<Array<{ annotation: Readonly<AnnotationV2>; line: number }>> {
+        const documents = new Map<string, vscode.TextDocument>();
+        const result: Array<{ annotation: Readonly<AnnotationV2>; line: number }> = [];
+        for (const id of ids) {
+            const annotation = this.store.get(id);
+            if (!annotation) {
+                continue;
+            }
+            let document = documents.get(annotation.fileUri);
+            if (!document) {
+                document = await vscode.workspace.openTextDocument(vscode.Uri.parse(annotation.fileUri));
+                documents.set(annotation.fileUri, document);
+            }
+            result.push({ annotation, line: document.positionAt(annotation.startOffset).line });
+        }
+        return result;
+    }
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -36,6 +36,7 @@ import { scanLineComments } from './comments/commentScanner';
 import { languageOfPath } from './comments/languageOfPath';
 import { captureAnchor } from './anchoring/anchor';
 import { TextBuffer } from './anchoring/textBuffer';
+import { AnnotationMoveService, type MoveAnnotationsRequest } from './commands/AnnotationMoveService';
 import { toFileUriString } from './common/fileUri';
 import { MarkdownMessageEditor } from './views/MarkdownMessageEditor';
 import { firstMessageLine, formatAnnotationLocation } from './views/markdownMessageEditorHelpers';
@@ -64,6 +65,7 @@ let annotationPersistence: AnnotationPersistence | undefined;
 let visibilityFilter: VisibilityFilter | undefined;
 let kanbanColumnStore: KanbanColumnStore | undefined;
 let annotationSyncService: AnnotationSyncService | undefined;
+let annotationMoveService: AnnotationMoveService | undefined;
 let selectedTreeAnnotationIds: string[] = [];
 
 /** Reentrancy guard for {@link generateDocumentationNow}. */
@@ -167,8 +169,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
             throw new Error('Lot 5 R2: transactional stack not bootstrapped before tree wiring');
         }
         const treeStore = annotationStore;
+        annotationMoveService = new AnnotationMoveService(treeStore, annotationPersistence);
         const treeDataProvider = new AnnotationsTreeDataProvider(treeStore, visibilityFilter);
-        const dragAndDropController = new AnnotationsDragAndDropController(treeStore, annotationPersistence);
+        const dragAndDropController = new AnnotationsDragAndDropController();
         const view = vscode.window.createTreeView('annotationsView', {
             treeDataProvider,
             dragAndDropController,
@@ -1491,6 +1494,76 @@ function registerStoreCommands(context: vscode.ExtensionContext): void {
             );
             vscode.window.setStatusBarMessage(loc('bulkActionComplete', 'Updated {0} annotations.', ids.length), 4000);
             return ids.length;
+        })
+    );
+
+    context.subscriptions.push(
+        vscode.commands.registerCommand('annotations.moveByDragAndDrop', async (commandArg?: unknown) => {
+            const store = annotationStore;
+            const moveService = annotationMoveService;
+            if (!store || !moveService) {
+                vscode.window.showErrorMessage(loc('storeNotReady', 'Annotation store is not ready yet.'));
+                return 0;
+            }
+
+            const raw = commandArg && typeof commandArg === 'object' ? (commandArg as Record<string, unknown>) : {};
+            let ids = Array.isArray(raw.ids)
+                ? raw.ids.filter((id): id is string => typeof id === 'string')
+                : selectedTreeAnnotationIds;
+            if (commandArg instanceof AnnotationTreeItem) {
+                ids = selectedTreeAnnotationIds.includes(commandArg.annotation.id)
+                    ? selectedTreeAnnotationIds
+                    : [commandArg.annotation.id];
+            }
+            if (ids.length === 0) {
+                const picked = await vscode.window.showQuickPick(
+                    store.list().map((annotation) => ({
+                        label: firstMessageLine(annotation.message) || annotation.id,
+                        description: annotation.file,
+                        id: annotation.id,
+                        picked: false,
+                    })),
+                    {
+                        canPickMany: true,
+                        title: loc('moveAnnotationsTitle', 'Move annotations'),
+                        placeHolder: loc('pickAnnotationsToMove', 'Select one or more annotations to move'),
+                        matchOnDescription: true,
+                    }
+                );
+                ids = picked?.map((item) => item.id) ?? [];
+            }
+            if (ids.length === 0) {
+                return 0;
+            }
+
+            const request: MoveAnnotationsRequest = {
+                ids,
+                ...(typeof raw.targetAnnotationId === 'string' ? { targetAnnotationId: raw.targetAnnotationId } : {}),
+                ...(typeof raw.targetFile === 'string' ? { targetFile: raw.targetFile } : {}),
+                ...(typeof raw.targetLine === 'number' ? { targetLine: raw.targetLine } : {}),
+            };
+            try {
+                const result = await moveService.move(request);
+                if (!result) {
+                    return 0;
+                }
+                vscode.window.setStatusBarMessage(
+                    loc(
+                        'annotationsMoved',
+                        'Moved {0} annotation(s) to {1}, line {2}.',
+                        result.movedIds.length,
+                        result.file,
+                        result.firstLine + 1
+                    ),
+                    5000
+                );
+                return result.movedIds.length;
+            } catch (error) {
+                const message = error instanceof Error ? error.message : String(error);
+                getLogger().error('Annotation drag-and-drop move failed', error);
+                vscode.window.showErrorMessage(loc('annotationMoveFailed', 'Unable to move annotations: {0}', message));
+                return 0;
+            }
         })
     );
 

--- a/src/managers/AnnotationManager.ts
+++ b/src/managers/AnnotationManager.ts
@@ -2271,6 +2271,13 @@ export class AnnotationManager extends EventEmitter {
                         action: message.action,
                     });
                     break;
+                case 'moveAnnotations':
+                    await vscode.commands.executeCommand('annotations.moveByDragAndDrop', {
+                        ids: message.annotationIds,
+                        targetAnnotationId: message.targetAnnotationId,
+                        targetFile: message.targetFile,
+                    });
+                    break;
                 case 'sort':
                     this.handleSort(message.value);
                     break;
@@ -2611,6 +2618,26 @@ export class AnnotationManager extends EventEmitter {
                 flex: 0 0 auto;
                 cursor: pointer;
             }
+            .drag-handle {
+                display: inline-flex;
+                align-items: center;
+                justify-content: center;
+                width: 1.7em;
+                height: 1.7em;
+                margin-right: 0.35em;
+                border: 1px solid transparent;
+                border-radius: 5px;
+                color: var(--vscode-descriptionForeground);
+                cursor: grab;
+                user-select: none;
+            }
+            .drag-handle:hover, .drag-handle:focus-visible {
+                color: var(--vscode-foreground);
+                border-color: var(--vscode-focusBorder);
+                background: var(--vscode-toolbar-hoverBackground);
+                outline: none;
+            }
+            .drag-handle:active { cursor: grabbing; }
             
             .file-group {
                 margin-bottom: 2em;
@@ -2664,6 +2691,19 @@ export class AnnotationManager extends EventEmitter {
                 background: var(--vscode-list-inactiveSelectionBackground);
                 box-shadow: 0 0 0 1px var(--vscode-focusBorder);
             }
+            .annotation-card.dragging { opacity: 0.48; transform: scale(0.99); }
+            .annotation-card.drop-target {
+                border-color: var(--vscode-focusBorder);
+                box-shadow: 0 0 0 2px var(--vscode-focusBorder), 0 10px 28px rgba(0, 0, 0, 0.18);
+                transform: translateY(-2px);
+            }
+            .file-group.drop-target > .file-header {
+                outline: 2px dashed var(--vscode-focusBorder);
+                outline-offset: 3px;
+                background: var(--vscode-list-inactiveSelectionBackground);
+            }
+            body.annotation-drag-active .annotation-card:not(.dragging),
+            body.annotation-drag-active .file-header { transition: outline 0.12s ease, transform 0.12s ease; }
             .annotation-card:focus-visible { outline: 2px solid var(--vscode-focusBorder); outline-offset: 2px; }
             
             /* Highlight enhancements during search */
@@ -2909,7 +2949,7 @@ export class AnnotationManager extends EventEmitter {
                         <div class="title">${loc('annotationsTitle', 'Out-of-Code Insights')}</div>
                     </div>
                     <div class="drag-hint">
-                        ${loc('dragHint', 'Move code with the editor’s native drag-and-drop: attached annotations now follow the block, including across files.')}
+                        ${loc('dragHint', 'Drag an annotation by its handle onto another card or file. Multi-selected annotations move together and keep their identity.')}
                     </div>
                 </div>
 
@@ -2971,6 +3011,7 @@ export class AnnotationManager extends EventEmitter {
                         ${loc('selectVisible', 'Select visible')}
                     </label>
                     <span id="selectedCount" class="bulk-count" role="status" aria-live="polite"></span>
+                    <button id="moveSelection" class="bulk-button" type="button">↔ ${loc('moveSelected', 'Move')}</button>
                     <button class="bulk-button" data-bulk-action="resolve" type="button">✓ ${loc('bulkResolve', 'Resolve')}</button>
                     <button class="bulk-button" data-bulk-action="reopen" type="button">○ ${loc('bulkReopen', 'Reopen')}</button>
                     <button class="bulk-button" data-bulk-action="severity" type="button">⚠ ${loc('bulkSeverity', 'Severity')}</button>
@@ -3015,6 +3056,13 @@ export class AnnotationManager extends EventEmitter {
                                  aria-label="${escapeHtml(`${annotation.file}, ${loc('line', 'Line')} ${annotation.line + 1}: ${annotation.message}`)}">
 
                                 <div class="annotation-header">
+                                    <span class="drag-handle"
+                                          draggable="true"
+                                          data-drag-annotation="${escapeHtml(annotation.id)}"
+                                          role="button"
+                                          tabindex="0"
+                                          title="${escapeHtml(loc('dragAnnotationTitle', 'Drag to move this annotation'))}"
+                                          aria-label="${escapeHtml(loc('dragAnnotationLabel', 'Move annotation: {0}', annotation.message))}">⋮⋮</span>
                                     <input class="annotation-select"
                                            type="checkbox"
                                            data-select-annotation="${escapeHtml(annotation.id)}"
@@ -3111,6 +3159,7 @@ export class AnnotationManager extends EventEmitter {
             const selectedCount = document.getElementById('selectedCount');
             const selectVisible = document.getElementById('selectVisible');
             const clearSelection = document.getElementById('clearSelection');
+            const moveSelection = document.getElementById('moveSelection');
             const selectionInputs = Array.from(document.querySelectorAll('[data-select-annotation]'));
             const selectedIds = new Set(Array.isArray(state.selectedAnnotationIds) ? state.selectedAnnotationIds : []);
 
@@ -3134,7 +3183,7 @@ export class AnnotationManager extends EventEmitter {
                     selectedCount.textContent = selectedIds.size + ' ${loc('selectedAnnotations', 'selected')}';
                 }
                 bulkToolbar?.classList.toggle('visible', selectedIds.size > 0);
-                document.querySelectorAll('[data-bulk-action], #clearSelection').forEach((button) => {
+                document.querySelectorAll('[data-bulk-action], #clearSelection, #moveSelection').forEach((button) => {
                     button.disabled = selectedIds.size === 0;
                 });
                 state.selectedAnnotationIds = Array.from(selectedIds);
@@ -3160,6 +3209,9 @@ export class AnnotationManager extends EventEmitter {
                 selectedIds.clear();
                 updateSelectionControls();
             });
+            moveSelection?.addEventListener('click', () => {
+                vscode.postMessage({ command: 'moveAnnotations', annotationIds: Array.from(selectedIds) });
+            });
             document.querySelectorAll('[data-bulk-action]').forEach((button) => {
                 button.addEventListener('click', () => {
                     vscode.postMessage({
@@ -3168,6 +3220,70 @@ export class AnnotationManager extends EventEmitter {
                         annotationIds: Array.from(selectedIds),
                     });
                 });
+            });
+
+            let draggedAnnotationIds = [];
+            function clearDropFeedback() {
+                document.body.classList.remove('annotation-drag-active');
+                document.querySelectorAll('.dragging, .drop-target').forEach((element) => {
+                    element.classList.remove('dragging', 'drop-target');
+                });
+            }
+            document.querySelectorAll('[data-drag-annotation]').forEach((handle) => {
+                handle.addEventListener('click', (event) => event.stopPropagation());
+                handle.addEventListener('keydown', (event) => {
+                    if (event.key !== 'Enter' && event.key !== ' ') return;
+                    event.preventDefault();
+                    event.stopPropagation();
+                    const id = handle.dataset.dragAnnotation;
+                    const ids = selectedIds.has(id) ? Array.from(selectedIds) : [id];
+                    vscode.postMessage({ command: 'moveAnnotations', annotationIds: ids });
+                });
+                handle.addEventListener('dragstart', (event) => {
+                    const id = handle.dataset.dragAnnotation;
+                    draggedAnnotationIds = selectedIds.has(id) ? Array.from(selectedIds) : [id];
+                    event.dataTransfer.effectAllowed = 'move';
+                    event.dataTransfer.setData(
+                        'application/vnd.out-of-code-insights.annotations+json',
+                        JSON.stringify({ version: 1, ids: draggedAnnotationIds })
+                    );
+                    event.dataTransfer.setData('text/plain', draggedAnnotationIds.join(','));
+                    handle.closest('.annotation-card')?.classList.add('dragging');
+                    document.body.classList.add('annotation-drag-active');
+                });
+                handle.addEventListener('dragend', () => {
+                    draggedAnnotationIds = [];
+                    clearDropFeedback();
+                });
+            });
+            document.addEventListener('dragover', (event) => {
+                if (draggedAnnotationIds.length === 0) return;
+                const card = event.target.closest?.('.annotation-card');
+                const group = event.target.closest?.('.file-group');
+                if (!card && !group) return;
+                event.preventDefault();
+                event.dataTransfer.dropEffect = 'move';
+                document.querySelectorAll('.drop-target').forEach((element) => element.classList.remove('drop-target'));
+                if (card) card.classList.add('drop-target');
+                else group?.classList.add('drop-target');
+            });
+            document.addEventListener('drop', (event) => {
+                if (draggedAnnotationIds.length === 0) return;
+                const card = event.target.closest?.('.annotation-card');
+                const group = event.target.closest?.('.file-group');
+                if (!card && !group) return;
+                event.preventDefault();
+                event.stopPropagation();
+                const targetAnnotationId = card?.dataset.annotationId;
+                const targetFile = card ? undefined : group?.dataset.file;
+                vscode.postMessage({
+                    command: 'moveAnnotations',
+                    annotationIds: draggedAnnotationIds,
+                    targetAnnotationId,
+                    targetFile,
+                });
+                draggedAnnotationIds = [];
+                clearDropFeedback();
             });
 
             // Restore state
@@ -3479,7 +3595,7 @@ export class AnnotationManager extends EventEmitter {
 
             // Event delegation replaces all inline onclick/onblur handlers.
             document.addEventListener('click', function(e) {
-                if (e.target.closest('[data-select-annotation], [data-bulk-action], #clearSelection, #selectVisible')) {
+                if (e.target.closest('[data-select-annotation], [data-drag-annotation], [data-bulk-action], #clearSelection, #moveSelection, #selectVisible')) {
                     return;
                 }
                 const btn = e.target.closest('[data-action]');

--- a/src/test/suite/lot12-reanchor-diagnostics.integration.test.ts
+++ b/src/test/suite/lot12-reanchor-diagnostics.integration.test.ts
@@ -151,4 +151,30 @@ suite('Lot 12 — manual re-anchor and local diagnostics commands', () => {
         await waitForAnnotation((candidate) => candidate.id === first.id && candidate.severity === 'critical');
         await waitForAnnotation((candidate) => candidate.id === second.id && candidate.severity === 'critical');
     });
+
+    test('move command preserves identity while re-anchoring across files', async function () {
+        this.timeout(20_000);
+        const sourceUri = await fixture('lot12-drag-source.ts', 'source zero\nsource move\n');
+        const targetUri = await fixture('lot12-drag-target.ts', 'target zero\ntarget one\ntarget destination\n');
+        const sourceDocument = await vscode.workspace.openTextDocument(sourceUri);
+        const targetDocument = await vscode.workspace.openTextDocument(targetUri);
+        await vscode.window.showTextDocument(sourceDocument);
+        await vscode.commands.executeCommand('annotations.add', { line: 1, message: 'lot12 dragged identity' });
+        await vscode.window.showTextDocument(targetDocument);
+        await vscode.commands.executeCommand('annotations.add', { line: 2, message: 'lot12 drag destination' });
+        const moved = await waitForAnnotation((candidate) => candidate.message === 'lot12 dragged identity');
+        const target = await waitForAnnotation((candidate) => candidate.message === 'lot12 drag destination');
+        createdIds.push(moved.id, target.id);
+
+        const count = await vscode.commands.executeCommand<number>('annotations.moveByDragAndDrop', {
+            ids: [moved.id],
+            targetAnnotationId: target.id,
+        });
+        assert.strictEqual(count, 1);
+        const persisted = await waitForAnnotation(
+            (candidate) => candidate.id === moved.id && candidate.fileUri === targetUri.toString()
+        );
+        assert.strictEqual(persisted.id, moved.id);
+        assert.strictEqual(targetDocument.positionAt(persisted.startOffset).line, 2);
+    });
 });

--- a/src/test/suite/lot5-display.integration.test.ts
+++ b/src/test/suite/lot5-display.integration.test.ts
@@ -10,8 +10,7 @@
 //   2. AnnotationCodeLensProvider — lenses appear at correct lines, hidden
 //      when globally disabled.
 //   3. NavigationStackDataProvider — purges entries on store.onDidDispose.
-//   4. AnnotationsDragAndDropController contract — handleDrop reorders via
-//      store.setAnnotationLine and persists via AnnotationPersistence.
+//   4. Drag-and-drop contract and identity-preserving cross-file moves.
 //
 // Note on placement: under src/test/suite/, NOT src/test/integration/, so
 // the suite runs in EDH (vscode runtime available). `npm run test:unit`
@@ -27,7 +26,9 @@ import {
     AnnotationsTreeDataProvider,
     FileTreeItem,
     AnnotationTreeItem,
+    parseAnnotationDragIds,
 } from '../../tree/AnnotationsTree';
+import { AnnotationMoveService } from '../../commands/AnnotationMoveService';
 import { NavigationStackDataProvider } from '../../tree/NavigationStackTree';
 import { AnnotationCodeLensProvider } from '../../providers/AnnotationCodeLensProvider';
 import { AnnotationPersistence } from '../../transactional/AnnotationPersistence';
@@ -352,11 +353,43 @@ suite('Lot 5 R2 worktree A — NavigationStackDataProvider', () => {
 
 suite('Lot 5 R2 worktree A — AnnotationsDragAndDropController contract', () => {
     test('exposes mime types and constructs without throwing', () => {
-        const store = new AnnotationStore();
-        const persistence = makeTmpPersistence();
-        const controller = new AnnotationsDragAndDropController(store, persistence);
+        const controller = new AnnotationsDragAndDropController();
         assert.deepStrictEqual(controller.dragMimeTypes, ['application/vnd.code.tree.annotation']);
         assert.deepStrictEqual(controller.dropMimeTypes, ['application/vnd.code.tree.annotation']);
+    });
+
+    test('parses versioned and legacy drag payloads', () => {
+        assert.deepStrictEqual(parseAnnotationDragIds(JSON.stringify({ version: 1, ids: ['a', 'b'] })), ['a', 'b']);
+        assert.deepStrictEqual(parseAnnotationDragIds('legacy-a,legacy-b'), ['legacy-a', 'legacy-b']);
+        assert.deepStrictEqual(parseAnnotationDragIds({ ids: ['not-a-string-payload'] }), []);
+    });
+
+    test('moves multiple annotations across files while preserving identity and relative spacing', async function () {
+        this.timeout(10000);
+        const sourceUri = await ensureFixture('lot5-drag-source.ts', 's0\ns1\ns2\ns3\ns4\n');
+        const targetUri = await ensureFixture('lot5-drag-target.ts', 't0\nt1\nt2\nt3\nt4\nt5\n');
+        const sourceDocument = await vscode.workspace.openTextDocument(sourceUri);
+        const targetDocument = await vscode.workspace.openTextDocument(targetUri);
+        const store = new AnnotationStore();
+        store.markInitialized();
+        const first = store.add(makeDraft(sourceUri, 'first dragged'), { line: 1 }, sourceDocument);
+        const second = store.add(makeDraft(sourceUri, 'second dragged'), { line: 3 }, sourceDocument);
+        const target = store.add(makeDraft(targetUri, 'drop target'), { line: 2 }, targetDocument);
+        const service = new AnnotationMoveService(store, makeTmpPersistence());
+
+        const result = await service.move({
+            ids: [first.id, second.id],
+            targetAnnotationId: target.id,
+        });
+
+        assert.deepStrictEqual(result?.movedIds, [first.id, second.id]);
+        const movedFirst = store.get(first.id);
+        const movedSecond = store.get(second.id);
+        assert.strictEqual(movedFirst?.fileUri, targetUri.toString());
+        assert.strictEqual(movedSecond?.fileUri, targetUri.toString());
+        assert.strictEqual(targetDocument.positionAt(movedFirst?.startOffset ?? -1).line, 2);
+        assert.strictEqual(targetDocument.positionAt(movedSecond?.startOffset ?? -1).line, 4);
+        assert.strictEqual(store.get(target.id)?.startOffset, target.startOffset, 'drop target must not move');
     });
 });
 

--- a/src/tree/AnnotationsTree.ts
+++ b/src/tree/AnnotationsTree.ts
@@ -10,12 +10,11 @@
 // `null`, which the UI renders as `?`.
 
 import * as vscode from 'vscode';
-import { localize } from '../common/localize';
+import { ANNOTATION_DRAG_MIME } from '../commands/AnnotationMoveService';
 import { loc } from '../managers/LocalizationManager';
 import type { AnnotationV2 } from '../transactional/types';
 import type { AnnotationStore } from '../transactional/AnnotationStore';
 import type { VisibilityFilter } from '../transactional/VisibilityFilter';
-import type { AnnotationPersistence } from '../transactional/AnnotationPersistence';
 
 /** Line+annotation pair used by the tree to render with already-resolved lines. */
 interface ResolvedAnnotation {
@@ -132,7 +131,7 @@ export class FileTreeItem extends vscode.TreeItem {
         this.tooltip = new vscode.MarkdownString(
             loc(
                 'fileTreeTooltip',
-                `**{0}**\n\n{1} open · {2} resolved · {3} need attention`,
+                `**{0}**\n\n{1} open · {2} resolved · {3} need attention\n\nDrop annotations here to choose a destination line.`,
                 file,
                 open,
                 resolved,
@@ -247,6 +246,10 @@ export class AnnotationTreeItem extends vscode.TreeItem {
         }
 
         tooltipContent += `\n${annotation.message}`;
+        tooltipContent += loc(
+            'annotationDragTooltip',
+            '\n\n---\nDrag onto another annotation to move it while preserving its identity.'
+        );
         this.tooltip = new vscode.MarkdownString(tooltipContent);
 
         let iconName = 'comment';
@@ -300,13 +303,8 @@ export class AnnotationTreeItem extends vscode.TreeItem {
 }
 
 export class AnnotationsDragAndDropController implements vscode.TreeDragAndDropController<vscode.TreeItem> {
-    public readonly dropMimeTypes = ['application/vnd.code.tree.annotation'];
-    public readonly dragMimeTypes = ['application/vnd.code.tree.annotation'];
-
-    constructor(
-        private readonly store: AnnotationStore,
-        private readonly persistence: AnnotationPersistence
-    ) {}
+    public readonly dropMimeTypes = [ANNOTATION_DRAG_MIME];
+    public readonly dragMimeTypes = [ANNOTATION_DRAG_MIME];
 
     async handleDrag(
         source: vscode.TreeItem[],
@@ -316,8 +314,10 @@ export class AnnotationsDragAndDropController implements vscode.TreeDragAndDropC
         const items = source.filter((s) => s instanceof AnnotationTreeItem) as AnnotationTreeItem[];
         if (items.length > 0) {
             dataTransfer.set(
-                'application/vnd.code.tree.annotation',
-                new vscode.DataTransferItem(items.map((i) => i.annotation.id).join(','))
+                ANNOTATION_DRAG_MIME,
+                new vscode.DataTransferItem(
+                    JSON.stringify({ version: 1, ids: items.map((item) => item.annotation.id) })
+                )
             );
         }
     }
@@ -327,99 +327,41 @@ export class AnnotationsDragAndDropController implements vscode.TreeDragAndDropC
         dataTransfer: vscode.DataTransfer,
         _token: vscode.CancellationToken
     ): Promise<void> {
-        const transferItem = dataTransfer.get('application/vnd.code.tree.annotation');
+        const transferItem = dataTransfer.get(ANNOTATION_DRAG_MIME);
         if (!transferItem) {
             return;
         }
 
-        const draggedAnnotationIds = (transferItem.value as string).split(',').filter((id) => id.trim().length > 0);
+        const draggedAnnotationIds = parseAnnotationDragIds(transferItem.value);
         if (draggedAnnotationIds.length === 0) {
             return;
         }
 
-        const draggedAnnotations = draggedAnnotationIds
-            .map((id) => this.store.get(id))
-            .filter((a): a is Readonly<AnnotationV2> => a !== undefined);
-        if (draggedAnnotations.length === 0) {
-            return;
-        }
-
-        let targetAnnotation: AnnotationV2 | undefined;
-        let targetFile: string | undefined;
-
         if (target instanceof AnnotationTreeItem) {
-            targetAnnotation = target.annotation;
-            targetFile = target.annotation.file;
+            await vscode.commands.executeCommand('annotations.moveByDragAndDrop', {
+                ids: draggedAnnotationIds,
+                targetAnnotationId: target.annotation.id,
+            });
         } else if (target instanceof FileTreeItem) {
-            targetFile = target.file;
-        } else {
-            return;
+            await vscode.commands.executeCommand('annotations.moveByDragAndDrop', {
+                ids: draggedAnnotationIds,
+                targetFile: target.file,
+            });
         }
-
-        const allSameFile = draggedAnnotations.every((a) => a.file === draggedAnnotations[0].file);
-        if (!allSameFile) {
-            vscode.window.showErrorMessage(
-                localize('cannotReorderDifferentFiles', 'Cannot reorder annotations from different files together.')
-            );
-            return;
-        }
-
-        const draggedFile = draggedAnnotations[0].file;
-        if (targetFile && targetFile !== draggedFile) {
-            vscode.window.showErrorMessage(
-                localize('cannotMoveToDifferentFile', 'Cannot move annotations to a different file via drag and drop.')
-            );
-            return;
-        }
-
-        const fileAnnotations = this.store
-            .list()
-            .filter((a) => a.file === draggedFile)
-            .slice()
-            .sort((a, b) => a.startOffset - b.startOffset);
-
-        for (const da of draggedAnnotations) {
-            const idx = fileAnnotations.findIndex((fa) => fa.id === da.id);
-            if (idx >= 0) {
-                fileAnnotations.splice(idx, 1);
-            }
-        }
-
-        let targetIndex: number;
-        if (targetAnnotation) {
-            const idx = fileAnnotations.findIndex((a) => a.id === targetAnnotation?.id);
-            targetIndex = idx >= 0 ? idx : fileAnnotations.length;
-        } else {
-            targetIndex = fileAnnotations.length;
-        }
-
-        fileAnnotations.splice(targetIndex + 1, 0, ...draggedAnnotations);
-
-        // Resolve the source document once for the offset recalc. Drag-drop
-        // preserves the legacy "line as panel-rank" semantics: each entry is
-        // re-anchored to its post-reorder index. This is intentional — the
-        // semantic was already overloaded in v1 and a behaviour-preserving
-        // port is the safer choice here. A clean rank-vs-anchor split is
-        // tracked as Q2 in the worktree A handoff.
-        const fileUri = draggedAnnotations[0].fileUri;
-        let document: vscode.TextDocument | undefined;
-        try {
-            document = await vscode.workspace.openTextDocument(vscode.Uri.parse(fileUri));
-        } catch {
-            vscode.window.showErrorMessage(
-                localize('cannotOpenDocumentForReorder', 'Cannot open the source document to reorder annotations.')
-            );
-            return;
-        }
-
-        for (let i = 0; i < fileAnnotations.length; i++) {
-            const a = fileAnnotations[i];
-            const targetLine = Math.min(i, document.lineCount - 1);
-            this.store.setAnnotationLine(a.id, targetLine, document);
-        }
-
-        await this.persistence.save(this.store.serialize());
-        this.store.notifyChanged();
-        vscode.window.showInformationMessage(localize('annotationsReordered', 'Annotations reordered successfully.'));
     }
+}
+
+export function parseAnnotationDragIds(value: unknown): string[] {
+    if (typeof value !== 'string') {
+        return [];
+    }
+    try {
+        const payload = JSON.parse(value) as { ids?: unknown };
+        if (Array.isArray(payload.ids)) {
+            return payload.ids.filter((id): id is string => typeof id === 'string' && id.trim().length > 0);
+        }
+    } catch {
+        // v1.4.0 and earlier encoded ids as a comma-separated string.
+    }
+    return value.split(',').filter((id) => id.trim().length > 0);
 }

--- a/tasks.jsonp
+++ b/tasks.jsonp
@@ -1,7 +1,7 @@
 globalThis.OOCI_TASKS = {
   "schemaVersion": 1,
   "project": "Out-of-Code Insights augmented platform",
-  "updatedAt": "2026-07-12T18:50:49-04:00",
+  "updatedAt": "2026-07-12T21:13:22-04:00",
   "statuses": ["todo", "in_progress", "blocked", "done", "accepted", "investigate"],
   "tasks": [
     {"id":"TRACK-001","area":"tracking","title":"Recognize paste over a selected range","status":"done"},
@@ -26,6 +26,11 @@ globalThis.OOCI_TASKS = {
     {"id":"UI-EXT-008","area":"vscode-ui","title":"Upgrade TreeView hierarchy, summaries, theme icons, accessibility and resolved-state checkboxes","status":"done"},
     {"id":"UI-EXT-009","area":"vscode-ui","title":"Add persisted multi-selection and transactional bulk actions to the annotations panel","status":"done"},
     {"id":"SDK-VSCODE-001","area":"microsoft-sdk","title":"Use TreeView badges, messages, multi-selection, checkbox events, context keys, ThemeColor and native QuickPick workflows","status":"done"},
+    {"id":"DND-EXT-001","area":"drag-drop","title":"Replace rank-based tree reorder with identity-preserving annotation re-anchoring","status":"done"},
+    {"id":"DND-EXT-002","area":"drag-drop","title":"Move multi-selected annotations across files from TreeView and panel drops","status":"done"},
+    {"id":"DND-EXT-003","area":"drag-drop","title":"Add keyboard-accessible Move Selected Annotations command and destination picker","status":"done"},
+    {"id":"UI-EXT-010","area":"vscode-ui","title":"Add panel drag handles, dragging state and card/file drop-target feedback","status":"done"},
+    {"id":"SDK-VSCODE-002","area":"microsoft-sdk","title":"Centralize TreeView, webview and command-palette moves behind one transactional VS Code command","status":"done"},
     {"id":"DESKTOP-001","area":"tauri","title":"Align desktop envelope and migrations 1:1 with extension","status":"in_progress"},
     {"id":"DESKTOP-002","area":"tauri","title":"Add direct drag-and-drop re-anchoring from table to code preview","status":"done"},
     {"id":"DESKTOP-003","area":"tauri","title":"Add bulk select/resolve/reopen/severity/delete workflows","status":"done"},
@@ -43,12 +48,16 @@ globalThis.OOCI_TASKS = {
     {"id":"QA-004","area":"quality","title":"Build/test Tauri frontend, 20 React tests and Rust backend","status":"done"},
     {"id":"QA-005","area":"quality","title":"Visual QA: desktop/narrow/high-contrast/reduced-motion","status":"blocked","blocker":"In-app browser runtime did not start; retry after environment recovery."},
     {"id":"QA-006","area":"quality","title":"Validate v1.4.0 native TreeView and panel bulk workflows","status":"done"},
+    {"id":"QA-007","area":"quality","title":"Validate v1.4.1 cross-file multi-annotation drag-and-drop workflows","status":"done"},
     {"id":"DOC-001","area":"documentation","title":"Modernize README positioning, onboarding, 1.3 recovery workflows, commands and troubleshooting","status":"done"},
     {"id":"DOC-002","area":"documentation","title":"Document v1.4.0 native tree, panel selection and Microsoft SDK workflows","status":"done"},
     {"id":"REL-001","area":"release","title":"Publish extension v1.2.1 to GitHub, VS Code Marketplace and Open VSX","status":"done"},
     {"id":"REL-002","area":"release","title":"Publish desktop v0.1.1 with NSIS and MSI installers","status":"done"},
     {"id":"REL-003","area":"release","title":"Publish extension v1.3.0 recovery, diagnostics and density release","status":"done"},
-    {"id":"REL-004","area":"release","title":"Publish extension v1.4.0 native tree and bulk panel release","status":"done"}
+    {"id":"REL-004","area":"release","title":"Publish extension v1.4.0 native tree and bulk panel release","status":"done"},
+    {"id":"REL-005","area":"release","title":"Publish extension v1.4.1 drag-and-drop movement release","status":"in_progress"},
+    {"id":"REL-006","area":"release","title":"Publish v1.4.2 deeper panel visual hierarchy and incremental rendering release","status":"todo"},
+    {"id":"REL-007","area":"release","title":"Publish v1.5.0 advanced editor-drop and workspace workflow release","status":"todo"}
   ],
   "productThoughts": [
     {"id":"THOUGHT-001","status":"accepted","text":"Identity must follow semantic code movement; line numbers and hashes alone are insufficient."},
@@ -60,6 +69,7 @@ globalThis.OOCI_TASKS = {
     {"id":"THOUGHT-007","status":"investigate","text":"A shared local operation ledger could reconcile concurrent extension/desktop writes without a server."},
     {"id":"THOUGHT-008","status":"investigate","text":"Retire the legacy manager after porting its clipboard heuristics; two lifecycle engines are a regression risk."},
     {"id":"THOUGHT-009","status":"accepted","text":"Tracking diagnostics must expose hashes and decisions without copying proprietary source text into reports."},
-    {"id":"THOUGHT-010","status":"accepted","text":"Use Microsoft VS Code native surfaces for selection, confirmation, theme, accessibility and commands; keep the webview focused on dense cross-file workflows."}
+    {"id":"THOUGHT-010","status":"accepted","text":"Use Microsoft VS Code native surfaces for selection, confirmation, theme, accessibility and commands; keep the webview focused on dense cross-file workflows."},
+    {"id":"THOUGHT-011","status":"accepted","text":"Ship focused patch releases at verified milestones instead of accumulating UI, tracking and workflow risk into one large release."}
   ]
 };


### PR DESCRIPTION
## What changed

- replaces the legacy rank-based tree reorder with identity-preserving re-anchoring
- supports cross-file and multi-selection moves from the native tree and annotations panel
- adds panel drag handles, card/file drop feedback, and a Move action in the selection toolbar
- adds a keyboard-accessible Move Selected Annotations command backed by native VS Code pickers
- records the staged 1.4.1 / 1.4.2 / later release cadence in tasks.jsonp

## Why

The previous tree drop implementation rewrote every annotation in a file to its list index and rejected cross-file movement. Users need a real move workflow that updates only the dragged annotations and preserves their ids and metadata.

## Validation

- TypeScript typecheck
- ESLint on changed sources
- 492 Node tests passing
- two focused VS Code Electron move tests passing
- production VSIX 1.4.1 packaged successfully
