### PR TITLE
Release v1.4.2 Drop Into Editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,21 +31,20 @@ local or be versioned and shared with the team.
 | Native VS Code experience     | Gutter decorations, CodeLens, Comments API threads, Tree View, commands, and keyboard access                 |
 | Automation and AI             | MCP tools, generated documentation, comment import, sync, and optional multi-provider AI features            |
 
-## What is new in 1.4.1
+## What is new in 1.4.2
 
-- Drag annotations onto another annotation in the native tree or the full panel
-  to re-anchor them at the destination, including across files.
-- Multi-selected annotations move together while preserving their identity,
+- Drag annotations from the native tree directly onto the exact destination
+  line in a code editor.
+- Multi-selected annotations move together and preserve their identity,
   discussions, metadata, and relative line spacing.
-- Panel cards now provide dedicated drag handles and visible card/file drop
-  targets.
-- **Move Selected Annotations…** provides the same workflow through native VS
-  Code pickers for keyboard and assistive-technology users.
-- Tree drops no longer rewrite every annotation line according to its list
-  position; only the explicitly dragged annotations move.
+- The move uses VS Code's native **Drop Into Editor** API and inserts no text in
+  the source document.
+- Panel drag handles emit the same annotation payload where the host supports
+  webview-to-editor dragging; **Move** remains the accessible fallback.
+- The 1.4.1 tree/panel card and file-group drop targets remain available.
 
-See the [1.4.1 release notes](./docs/CHANGELOG-1.4.1.md) or the
-[published release](https://github.com/JacquesGariepy/out-of-code-insights/releases/tag/v1.4.1).
+See the [1.4.2 release notes](./docs/CHANGELOG-1.4.2.md) or the
+[published release](https://github.com/JacquesGariepy/out-of-code-insights/releases/tag/v1.4.2).
 
 ## Start in 60 seconds
 
@@ -257,6 +256,8 @@ Attach and execute code directly from annotations:
   affected lines and blocks.
 - Drag an annotation row onto another row in the native tree, or use the drag
   handle on a panel card, to move the annotation to that code location.
+- Drag a native tree row directly onto a line in an open code editor to attach
+  it to that exact line without modifying the source text.
 - Multi-select annotations before dragging to move the set together. Drop on a
   file group to choose an exact line with the native destination picker.
 - Run **Move Selected Annotations…** for the keyboard-accessible equivalent.
@@ -990,6 +991,14 @@ These features enhance annotation management by providing an overview and manage
 4. Check the report for `line-hash-mismatch`, `offset-out-of-document`, or
    `awaiting-paste`. The report contains no source text and is safe to inspect
    locally before sharing.
+
+#### "Dropping an annotation into the code editor does nothing"
+
+- Confirm the VS Code setting `editor.dropIntoEditor.enabled` is enabled.
+- Start the drag from an annotation row in the native Out-of-Code Insights
+  Tree View, then release it on the destination code line.
+- Use **Move Selected Annotations…** or the panel's **Move** button when drag
+  transfer is unavailable in the current host.
 
 #### "Template variables not working"
 

--- a/docs/CHANGELOG-1.4.2.md
+++ b/docs/CHANGELOG-1.4.2.md
@@ -1,0 +1,21 @@
+# Out-of-Code Insights 1.4.2
+
+This focused release extends annotation drag-and-drop onto the code editor itself.
+
+## Drop Into Editor
+
+- Drag an annotation from the native TreeView directly onto the exact destination line in a code editor.
+- Multi-selected annotations move together and keep their relative line spacing.
+- The destination file, URI, language, offsets, line hash and surrounding context are recaptured from the code document.
+- The drop uses Microsoft VS Code's `DocumentDropEditProvider` and a versioned annotation MIME payload.
+- Moving annotation metadata inserts no text and makes no source-code modification.
+
+## Panel integration
+
+- Panel drag handles emit the same annotation MIME payload used by the native tree.
+- Environments that forward webview drag payloads to the workbench can use the same code-editor target.
+- The existing **Move** button remains the reliable keyboard-accessible alternative.
+
+## Release cadence
+
+This capability is published separately from the 1.4.1 tree/panel movement release. The deeper visual hierarchy and incremental panel rendering remain isolated in the planned 1.4.3 release.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "out-of-code-insights",
-    "version": "1.4.1",
+    "version": "1.4.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "out-of-code-insights",
-            "version": "1.4.1",
+            "version": "1.4.2",
             "license": "MPL-2.0",
             "dependencies": {
                 "@anthropic-ai/claude-code": "^2.1.177",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "description": "Enhance your workflow with contextual annotations and collaborative comments stored outside the codebase, with AI integration and a dedicated chat participant.",
     "icon": "media/logo.png",
     "publisher": "jacquesgariepy",
-    "version": "1.4.1",
+    "version": "1.4.2",
     "license": "MPL-2.0",
     "author": {
         "name": "Jacques Gariépy",

--- a/src/commands/AnnotationMoveService.ts
+++ b/src/commands/AnnotationMoveService.ts
@@ -7,10 +7,26 @@ import type { AnnotationV2 } from '../transactional/types';
 
 export const ANNOTATION_DRAG_MIME = 'application/vnd.code.tree.annotation';
 
+export function parseAnnotationDragIds(value: unknown): string[] {
+    if (typeof value !== 'string') {
+        return [];
+    }
+    try {
+        const payload = JSON.parse(value) as { ids?: unknown };
+        if (Array.isArray(payload.ids)) {
+            return payload.ids.filter((id): id is string => typeof id === 'string' && id.trim().length > 0);
+        }
+    } catch {
+        // v1.4.0 and earlier encoded ids as a comma-separated string.
+    }
+    return value.split(',').filter((id) => id.trim().length > 0);
+}
+
 export interface MoveAnnotationsRequest {
     ids: readonly string[];
     targetAnnotationId?: string;
     targetFile?: string;
+    targetUri?: string;
     targetLine?: number;
 }
 
@@ -111,6 +127,17 @@ export class AnnotationMoveService {
             if (!targetAnnotation) {
                 return undefined;
             }
+        }
+
+        if (!targetAnnotation && request.targetUri) {
+            const document = await vscode.workspace.openTextDocument(vscode.Uri.parse(request.targetUri));
+            let line = request.targetLine;
+            if (line === undefined) {
+                line = await this.pickDestinationLine(document, 0);
+            }
+            return line === undefined
+                ? undefined
+                : { document, line: Math.max(0, Math.min(document.lineCount - 1, line)) };
         }
 
         const fileCandidate = targetAnnotation

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -31,6 +31,10 @@ import { AnnotationPersistence } from './transactional/AnnotationPersistence';
 import { VisibilityFilter } from './transactional/VisibilityFilter';
 import { KanbanColumnStore } from './transactional/KanbanColumnStore';
 import { AnnotationCodeLensProvider } from './providers/AnnotationCodeLensProvider';
+import {
+    AnnotationDocumentDropEditProvider,
+    annotationDocumentDropMetadata,
+} from './providers/AnnotationDocumentDropEditProvider';
 import { generateDocSet, type DocAnnotation } from './docs/AnnotationDocGenerator';
 import { scanLineComments } from './comments/commentScanner';
 import { languageOfPath } from './comments/languageOfPath';
@@ -170,6 +174,13 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         }
         const treeStore = annotationStore;
         annotationMoveService = new AnnotationMoveService(treeStore, annotationPersistence);
+        context.subscriptions.push(
+            vscode.languages.registerDocumentDropEditProvider(
+                { scheme: 'file' },
+                new AnnotationDocumentDropEditProvider(annotationMoveService),
+                annotationDocumentDropMetadata
+            )
+        );
         const treeDataProvider = new AnnotationsTreeDataProvider(treeStore, visibilityFilter);
         const dragAndDropController = new AnnotationsDragAndDropController();
         const view = vscode.window.createTreeView('annotationsView', {
@@ -1540,6 +1551,7 @@ function registerStoreCommands(context: vscode.ExtensionContext): void {
                 ids,
                 ...(typeof raw.targetAnnotationId === 'string' ? { targetAnnotationId: raw.targetAnnotationId } : {}),
                 ...(typeof raw.targetFile === 'string' ? { targetFile: raw.targetFile } : {}),
+                ...(typeof raw.targetUri === 'string' ? { targetUri: raw.targetUri } : {}),
                 ...(typeof raw.targetLine === 'number' ? { targetLine: raw.targetLine } : {}),
             };
             try {

--- a/src/managers/AnnotationManager.ts
+++ b/src/managers/AnnotationManager.ts
@@ -2949,7 +2949,7 @@ export class AnnotationManager extends EventEmitter {
                         <div class="title">${loc('annotationsTitle', 'Out-of-Code Insights')}</div>
                     </div>
                     <div class="drag-hint">
-                        ${loc('dragHint', 'Drag an annotation by its handle onto another card or file. Multi-selected annotations move together and keep their identity.')}
+                        ${loc('dragHint', 'Drag an annotation by its handle onto another card, file, or code editor line. Multi-selected annotations move together and keep their identity.')}
                     </div>
                 </div>
 
@@ -3244,10 +3244,9 @@ export class AnnotationManager extends EventEmitter {
                     draggedAnnotationIds = selectedIds.has(id) ? Array.from(selectedIds) : [id];
                     event.dataTransfer.effectAllowed = 'move';
                     event.dataTransfer.setData(
-                        'application/vnd.out-of-code-insights.annotations+json',
+                        'application/vnd.code.tree.annotation',
                         JSON.stringify({ version: 1, ids: draggedAnnotationIds })
                     );
-                    event.dataTransfer.setData('text/plain', draggedAnnotationIds.join(','));
                     handle.closest('.annotation-card')?.classList.add('dragging');
                     document.body.classList.add('annotation-drag-active');
                 });

--- a/src/providers/AnnotationDocumentDropEditProvider.ts
+++ b/src/providers/AnnotationDocumentDropEditProvider.ts
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: MPL-2.0
+import * as vscode from 'vscode';
+import { ANNOTATION_DRAG_MIME, AnnotationMoveService, parseAnnotationDragIds } from '../commands/AnnotationMoveService';
+import { loc } from '../managers/LocalizationManager';
+import { getLogger } from '../utils/logger';
+
+export const ANNOTATION_EDITOR_DROP_KIND = vscode.DocumentDropOrPasteEditKind.Empty.append(
+    'outOfCodeInsights',
+    'moveAnnotation'
+);
+
+/** Moves TreeView annotations onto the exact line where they are dropped in a code editor. */
+export class AnnotationDocumentDropEditProvider implements vscode.DocumentDropEditProvider {
+    constructor(private readonly moveService: AnnotationMoveService) {}
+
+    async provideDocumentDropEdits(
+        document: vscode.TextDocument,
+        position: vscode.Position,
+        dataTransfer: vscode.DataTransfer,
+        token: vscode.CancellationToken
+    ): Promise<vscode.DocumentDropEdit | undefined> {
+        const item = dataTransfer.get(ANNOTATION_DRAG_MIME);
+        if (!item || token.isCancellationRequested) {
+            return undefined;
+        }
+
+        const ids = parseAnnotationDragIds(await item.asString());
+        if (ids.length === 0 || token.isCancellationRequested) {
+            return undefined;
+        }
+
+        try {
+            const result = await this.moveService.move({
+                ids,
+                targetFile: vscode.workspace.asRelativePath(document.uri),
+                targetUri: document.uri.toString(),
+                targetLine: position.line,
+            });
+            if (!result) {
+                return undefined;
+            }
+
+            vscode.window.setStatusBarMessage(
+                loc(
+                    'editorDropComplete',
+                    'Moved {0} annotation(s) to {1}, line {2}.',
+                    result.movedIds.length,
+                    result.file,
+                    result.firstLine + 1
+                ),
+                5000
+            );
+            return new vscode.DocumentDropEdit(
+                '',
+                loc('editorDropTitle', 'Move annotations here'),
+                ANNOTATION_EDITOR_DROP_KIND
+            );
+        } catch (error) {
+            const message = error instanceof Error ? error.message : String(error);
+            getLogger().error('Drop Into Editor annotation move failed', error);
+            vscode.window.showErrorMessage(loc('editorDropFailed', 'Unable to move annotations here: {0}', message));
+            return undefined;
+        }
+    }
+}
+
+export const annotationDocumentDropMetadata: vscode.DocumentDropEditProviderMetadata = {
+    dropMimeTypes: [ANNOTATION_DRAG_MIME],
+    providedDropEditKinds: [ANNOTATION_EDITOR_DROP_KIND],
+};

--- a/src/test/suite/lot5-display.integration.test.ts
+++ b/src/test/suite/lot5-display.integration.test.ts
@@ -26,9 +26,12 @@ import {
     AnnotationsTreeDataProvider,
     FileTreeItem,
     AnnotationTreeItem,
-    parseAnnotationDragIds,
 } from '../../tree/AnnotationsTree';
-import { AnnotationMoveService } from '../../commands/AnnotationMoveService';
+import { AnnotationMoveService, parseAnnotationDragIds } from '../../commands/AnnotationMoveService';
+import {
+    AnnotationDocumentDropEditProvider,
+    annotationDocumentDropMetadata,
+} from '../../providers/AnnotationDocumentDropEditProvider';
 import { NavigationStackDataProvider } from '../../tree/NavigationStackTree';
 import { AnnotationCodeLensProvider } from '../../providers/AnnotationCodeLensProvider';
 import { AnnotationPersistence } from '../../transactional/AnnotationPersistence';
@@ -390,6 +393,42 @@ suite('Lot 5 R2 worktree A — AnnotationsDragAndDropController contract', () =>
         assert.strictEqual(targetDocument.positionAt(movedFirst?.startOffset ?? -1).line, 2);
         assert.strictEqual(targetDocument.positionAt(movedSecond?.startOffset ?? -1).line, 4);
         assert.strictEqual(store.get(target.id)?.startOffset, target.startOffset, 'drop target must not move');
+    });
+
+    test('moves a tree annotation onto the exact editor drop line without inserting text', async function () {
+        this.timeout(10000);
+        const sourceUri = await ensureFixture('lot5-drag-editor-source.ts', 'source zero\nsource annotation\n');
+        const targetUri = await ensureFixture(
+            'lot5-drag-editor-target.ts',
+            'target zero\ntarget one\ntarget two\ntarget three\n'
+        );
+        const sourceDocument = await vscode.workspace.openTextDocument(sourceUri);
+        const targetDocument = await vscode.workspace.openTextDocument(targetUri);
+        const store = new AnnotationStore();
+        store.markInitialized();
+        const annotation = store.add(makeDraft(sourceUri, 'drop into editor'), { line: 1 }, sourceDocument);
+        const provider = new AnnotationDocumentDropEditProvider(new AnnotationMoveService(store, makeTmpPersistence()));
+        const transfer = new vscode.DataTransfer();
+        transfer.set(
+            'application/vnd.code.tree.annotation',
+            new vscode.DataTransferItem(JSON.stringify({ version: 1, ids: [annotation.id] }))
+        );
+        const cancellation = new vscode.CancellationTokenSource();
+
+        const edit = await provider.provideDocumentDropEdits(
+            targetDocument,
+            new vscode.Position(3, 4),
+            transfer,
+            cancellation.token
+        );
+        cancellation.dispose();
+
+        assert.ok(edit, 'the custom tree payload should produce a native DocumentDropEdit');
+        assert.strictEqual(edit.insertText, '', 'moving metadata must not insert text into source code');
+        assert.deepStrictEqual(annotationDocumentDropMetadata.dropMimeTypes, ['application/vnd.code.tree.annotation']);
+        const moved = store.get(annotation.id);
+        assert.strictEqual(moved?.fileUri, targetUri.toString());
+        assert.strictEqual(targetDocument.positionAt(moved?.startOffset ?? -1).line, 3);
     });
 });
 

--- a/src/tree/AnnotationsTree.ts
+++ b/src/tree/AnnotationsTree.ts
@@ -10,7 +10,7 @@
 // `null`, which the UI renders as `?`.
 
 import * as vscode from 'vscode';
-import { ANNOTATION_DRAG_MIME } from '../commands/AnnotationMoveService';
+import { ANNOTATION_DRAG_MIME, parseAnnotationDragIds } from '../commands/AnnotationMoveService';
 import { loc } from '../managers/LocalizationManager';
 import type { AnnotationV2 } from '../transactional/types';
 import type { AnnotationStore } from '../transactional/AnnotationStore';
@@ -248,7 +248,7 @@ export class AnnotationTreeItem extends vscode.TreeItem {
         tooltipContent += `\n${annotation.message}`;
         tooltipContent += loc(
             'annotationDragTooltip',
-            '\n\n---\nDrag onto another annotation to move it while preserving its identity.'
+            '\n\n---\nDrag onto another annotation or directly onto a code editor line to move it while preserving its identity.'
         );
         this.tooltip = new vscode.MarkdownString(tooltipContent);
 
@@ -349,19 +349,4 @@ export class AnnotationsDragAndDropController implements vscode.TreeDragAndDropC
             });
         }
     }
-}
-
-export function parseAnnotationDragIds(value: unknown): string[] {
-    if (typeof value !== 'string') {
-        return [];
-    }
-    try {
-        const payload = JSON.parse(value) as { ids?: unknown };
-        if (Array.isArray(payload.ids)) {
-            return payload.ids.filter((id): id is string => typeof id === 'string' && id.trim().length > 0);
-        }
-    } catch {
-        // v1.4.0 and earlier encoded ids as a comma-separated string.
-    }
-    return value.split(',').filter((id) => id.trim().length > 0);
 }

--- a/tasks.jsonp
+++ b/tasks.jsonp
@@ -1,7 +1,7 @@
 globalThis.OOCI_TASKS = {
   "schemaVersion": 1,
   "project": "Out-of-Code Insights augmented platform",
-  "updatedAt": "2026-07-12T21:13:22-04:00",
+  "updatedAt": "2026-07-12T21:43:05-04:00",
   "statuses": ["todo", "in_progress", "blocked", "done", "accepted", "investigate"],
   "tasks": [
     {"id":"TRACK-001","area":"tracking","title":"Recognize paste over a selected range","status":"done"},
@@ -31,6 +31,8 @@ globalThis.OOCI_TASKS = {
     {"id":"DND-EXT-003","area":"drag-drop","title":"Add keyboard-accessible Move Selected Annotations command and destination picker","status":"done"},
     {"id":"UI-EXT-010","area":"vscode-ui","title":"Add panel drag handles, dragging state and card/file drop-target feedback","status":"done"},
     {"id":"SDK-VSCODE-002","area":"microsoft-sdk","title":"Centralize TreeView, webview and command-palette moves behind one transactional VS Code command","status":"done"},
+    {"id":"DND-EXT-004","area":"drag-drop","title":"Move TreeView and panel annotations onto the exact line dropped in the code editor","status":"done"},
+    {"id":"SDK-VSCODE-003","area":"microsoft-sdk","title":"Integrate DocumentDropEditProvider and custom annotation MIME without inserting source text","status":"done"},
     {"id":"DESKTOP-001","area":"tauri","title":"Align desktop envelope and migrations 1:1 with extension","status":"in_progress"},
     {"id":"DESKTOP-002","area":"tauri","title":"Add direct drag-and-drop re-anchoring from table to code preview","status":"done"},
     {"id":"DESKTOP-003","area":"tauri","title":"Add bulk select/resolve/reopen/severity/delete workflows","status":"done"},
@@ -49,15 +51,17 @@ globalThis.OOCI_TASKS = {
     {"id":"QA-005","area":"quality","title":"Visual QA: desktop/narrow/high-contrast/reduced-motion","status":"blocked","blocker":"In-app browser runtime did not start; retry after environment recovery."},
     {"id":"QA-006","area":"quality","title":"Validate v1.4.0 native TreeView and panel bulk workflows","status":"done"},
     {"id":"QA-007","area":"quality","title":"Validate v1.4.1 cross-file multi-annotation drag-and-drop workflows","status":"done"},
+    {"id":"QA-008","area":"quality","title":"Validate v1.4.2 Drop Into Editor movement and zero-text insertion","status":"done"},
     {"id":"DOC-001","area":"documentation","title":"Modernize README positioning, onboarding, 1.3 recovery workflows, commands and troubleshooting","status":"done"},
     {"id":"DOC-002","area":"documentation","title":"Document v1.4.0 native tree, panel selection and Microsoft SDK workflows","status":"done"},
     {"id":"REL-001","area":"release","title":"Publish extension v1.2.1 to GitHub, VS Code Marketplace and Open VSX","status":"done"},
     {"id":"REL-002","area":"release","title":"Publish desktop v0.1.1 with NSIS and MSI installers","status":"done"},
     {"id":"REL-003","area":"release","title":"Publish extension v1.3.0 recovery, diagnostics and density release","status":"done"},
     {"id":"REL-004","area":"release","title":"Publish extension v1.4.0 native tree and bulk panel release","status":"done"},
-    {"id":"REL-005","area":"release","title":"Publish extension v1.4.1 drag-and-drop movement release","status":"in_progress"},
-    {"id":"REL-006","area":"release","title":"Publish v1.4.2 deeper panel visual hierarchy and incremental rendering release","status":"todo"},
-    {"id":"REL-007","area":"release","title":"Publish v1.5.0 advanced editor-drop and workspace workflow release","status":"todo"}
+    {"id":"REL-005","area":"release","title":"Publish extension v1.4.1 drag-and-drop movement release","status":"done"},
+    {"id":"REL-006","area":"release","title":"Publish v1.4.2 Drop Into Editor movement release","status":"in_progress"},
+    {"id":"REL-007","area":"release","title":"Publish v1.5.0 advanced workspace workflow release","status":"todo"},
+    {"id":"REL-008","area":"release","title":"Publish v1.4.3 deeper panel visual hierarchy and incremental rendering release","status":"todo"}
   ],
   "productThoughts": [
     {"id":"THOUGHT-001","status":"accepted","text":"Identity must follow semantic code movement; line numbers and hashes alone are insufficient."},


### PR DESCRIPTION
## What changed

- registers a Microsoft VS Code DocumentDropEditProvider for annotation tree payloads
- moves one or many annotations onto the exact editor line where they are dropped
- accepts empty target files that do not yet contain annotations
- returns an empty DocumentDropEdit so no source text is inserted
- aligns panel drag MIME data with the native tree and documents the fallback command
- publishes this editor capability separately as version 1.4.2

## Why

After 1.4.1 added real tree and panel movement, annotations still needed a direct code-page destination. Users should be able to drag from the annotations UI to the exact code line without editing source text or losing annotation identity.

## Validation

- TypeScript typecheck
- ESLint on changed sources
- direct Electron provider test verifies exact target line and empty insertText
- extension activation smoke test verifies provider registration
- VSIX 1.4.2 packaged and manifest/hash verified
