### PR TITLE
Mark v1.4.2 release complete

### DIFF
--- a/tasks.jsonp
+++ b/tasks.jsonp
@@ -1,7 +1,7 @@
 globalThis.OOCI_TASKS = {
   "schemaVersion": 1,
   "project": "Out-of-Code Insights augmented platform",
-  "updatedAt": "2026-07-12T21:43:05-04:00",
+  "updatedAt": "2026-07-12T22:16:16-04:00",
   "statuses": ["todo", "in_progress", "blocked", "done", "accepted", "investigate"],
   "tasks": [
     {"id":"TRACK-001","area":"tracking","title":"Recognize paste over a selected range","status":"done"},
@@ -59,7 +59,7 @@ globalThis.OOCI_TASKS = {
     {"id":"REL-003","area":"release","title":"Publish extension v1.3.0 recovery, diagnostics and density release","status":"done"},
     {"id":"REL-004","area":"release","title":"Publish extension v1.4.0 native tree and bulk panel release","status":"done"},
     {"id":"REL-005","area":"release","title":"Publish extension v1.4.1 drag-and-drop movement release","status":"done"},
-    {"id":"REL-006","area":"release","title":"Publish v1.4.2 Drop Into Editor movement release","status":"in_progress"},
+    {"id":"REL-006","area":"release","title":"Publish v1.4.2 Drop Into Editor movement release","status":"done"},
     {"id":"REL-007","area":"release","title":"Publish v1.5.0 advanced workspace workflow release","status":"todo"},
     {"id":"REL-008","area":"release","title":"Publish v1.4.3 deeper panel visual hierarchy and incremental rendering release","status":"todo"}
   ],


### PR DESCRIPTION
Records the successful GitHub, VS Code Marketplace, and Open VSX publication of the separate Drop Into Editor release.